### PR TITLE
fix: use anonymous presets as now supported by `gptel-with-preset`

### DIFF
--- a/Eask
+++ b/Eask
@@ -1,5 +1,5 @@
 ;; -*- mode: lisp -*-
-(package "macher" "0.2.0" "LLM implementation toolset")
+(package "macher" "0.2.1" "LLM implementation toolset")
 
 (website-url "https://github.com/kmontag/macher")
 (keywords "convenience" "gptel" "llm")

--- a/macher.el
+++ b/macher.el
@@ -2022,18 +2022,11 @@ from the global gptel registry - it's for cases where you want to use a
 well-defined preset independent of how gptel is currently configured.
 
 CALLBACK takes no arguments."
-  ;; `gptel-with-preset' only works with presets that are globally registered. Momentarily add to
-  ;; the known presets list while executing the callback.
-  (let ((name (gensym "__macher-temp-preset-")))
-    (unwind-protect
-        (progn
-          (let ((spec
-                 (if (symbolp preset)
-                     (cdr (assq preset macher--presets-alist))
-                   preset)))
-            (apply #'gptel-make-preset name spec))
-          (eval `(gptel-with-preset ,name (funcall ,callback))))
-      (setq gptel--known-presets (assq-delete-all name gptel--known-presets)))))
+  (let ((spec
+         (if (symbolp preset)
+             (cdr (assq preset macher--presets-alist))
+           preset)))
+    (gptel-with-preset spec (funcall callback))))
 
 (defun macher--preset-default ()
   "Set up the default macher preset with full editing capabilities."

--- a/macher.el
+++ b/macher.el
@@ -1,7 +1,7 @@
 ;;; macher.el --- LLM implementation toolset -*- lexical-binding: t -*-
 
 ;; Author: Kevin Montag
-;; Version: 0.2.0
+;; Version: 0.2.1
 ;; Package-Requires: ((emacs "30.1") (gptel "0.9.8.5"))
 ;; Keywords: convenience, gptel, llm
 ;; URL: https://github.com/kmontag/macher

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -712,40 +712,32 @@
       (setq gptel--known-presets original-presets))
 
     (it "applies macher preset with callback"
-      (let ((callback-called nil)
-            (callback-result nil))
+      (let ((callback-called nil))
         (expect gptel--known-presets :to-be nil)
         (expect gptel-tools :to-be nil)
         (macher--with-preset
          'macher
          (lambda ()
            (expect gptel-tools :not :to-be nil)
-           (setq callback-called t)
-           (setq callback-result gptel--known-presets)))
+           (setq callback-called t)))
         ;; Verify the callback was called.
         (expect callback-called :to-be-truthy)
-        ;; Verify the preset was temporarily registered during the callback.
-        (expect (length callback-result) :to-be 1)
-        ;; Verify global state is cleaned up after the callback.
+        ;; Verify global state was not modified by the callback.
         (expect gptel-tools :to-be nil)
         (expect gptel--known-presets :to-be nil)))
 
     (it "applies macher-ro preset with callback"
-      (let ((callback-called nil)
-            (callback-result nil))
+      (let ((callback-called nil))
         (expect gptel--known-presets :to-be nil)
         (expect gptel-tools :to-be nil)
         (macher--with-preset
          'macher-ro
          (lambda ()
            (expect gptel-tools :not :to-be nil)
-           (setq callback-called t)
-           (setq callback-result gptel--known-presets)))
+           (setq callback-called t)))
         ;; Verify the callback was called.
         (expect callback-called :to-be-truthy)
-        ;; Verify the preset was temporarily registered during the callback.
-        (expect callback-result :not :to-be nil)
-        ;; Verify the global state is cleaned up after the callback.
+        ;; Verify the global state was not modified by the callback.
         (expect gptel-tools :to-be nil)
         (expect gptel--known-presets :to-be nil)))
 
@@ -754,19 +746,16 @@
 
     (it "accepts raw preset spec"
       (let ((callback-called nil)
-            (callback-result nil)
+
             (gptel-use-tools nil))
         (macher--with-preset
          '(:use-tools t :description "Test preset")
          (lambda ()
            (expect gptel-use-tools :to-be t)
-           (setq callback-called t)
-           (setq callback-result gptel--known-presets)))
+           (setq callback-called t)))
         ;; Verify the callback was called.
         (expect callback-called :to-be-truthy)
-        ;; Verify the preset was temporarily registered during the callback.
-        (expect callback-result :not :to-be nil)
-        ;; Verify gptel--known-presets is cleaned up after the callback.
+        ;; Verify global state was not modified by the callback.
         (expect gptel-use-tools :to-be nil)
         (expect gptel--known-presets :to-be nil)))
 


### PR DESCRIPTION
This update is required to use macher with the latest version of gptel.

Conversely, you'll need to update gptel to at least https://github.com/karthink/gptel/commit/7218aedd6f8294af5be876c0c18a733863156b7b in tandem with this update.

Fixes #7 