### PR TITLE
feat: new search/ls tools + improvements to existing tools

### DIFF
--- a/Eask
+++ b/Eask
@@ -1,5 +1,5 @@
 ;; -*- mode: lisp -*-
-(package "macher" "0.2.1" "LLM implementation toolset")
+(package "macher" "0.3.0" "LLM implementation toolset")
 
 (website-url "https://github.com/kmontag/macher")
 (keywords "convenience" "gptel" "llm")

--- a/macher.el
+++ b/macher.el
@@ -1,7 +1,7 @@
 ;;; macher.el --- LLM implementation toolset -*- lexical-binding: t -*-
 
 ;; Author: Kevin Montag
-;; Version: 0.2.1
+;; Version: 0.3.0
 ;; Package-Requires: ((emacs "30.1") (gptel "0.9.8.5"))
 ;; Keywords: convenience, gptel, llm
 ;; URL: https://github.com/kmontag/macher

--- a/macher.el
+++ b/macher.el
@@ -430,6 +430,10 @@ To add a new workspace type, add an entry to this alist and update
   :type '(alist :key-type symbol :value-type (plist :key-type keyword :value-type function))
   :group 'macher)
 
+;;; Constants
+
+(defconst macher--max-read-length (* 1024 1024)
+  "Max number of bytes to return from the read tool.")
 
 ;;; Variables
 
@@ -535,7 +539,10 @@ Returns (file . FILENAME) if the buffer is visiting a file, nil otherwise."
   "Get the project root for PROJECT-ID, validating it's a real project root."
   (require 'project)
   ;; Verify that project-id is actually a valid project root directory.
-  (unless (and (stringp project-id) (file-directory-p project-id) (project-current nil project-id))
+  (unless (and (stringp project-id)
+               (file-name-absolute-p project-id)
+               (file-directory-p project-id)
+               (project-current nil project-id))
     (error "Project ID '%s' is not a valid project root directory" project-id))
   project-id)
 
@@ -578,8 +585,13 @@ it returns nil."
 
 (defun macher--workspace-root (workspace)
   "Get the workspace root for WORKSPACE.
+
 WORKSPACE is a cons cell (TYPE . ID) where TYPE is a workspace type.
-Returns the root directory path for the workspace."
+Returns the root directory path for the workspace.
+
+Uses the appropriate root function as configured in the
+'macher-workspace-types-alist', and validates that the result is an
+absolute path to a real directory."
   (let* ((workspace-type (car workspace))
          (workspace-id (cdr workspace))
          (type-config (alist-get workspace-type macher-workspace-types-alist))
@@ -590,7 +602,9 @@ Returns the root directory path for the workspace."
                   (error
                    "Root function for workspace type %s failed to return a root" workspace-type))
             (error "No root function configured for workspace type %s" workspace-type))))
-    ;; Verify that the root is a real directory
+    ;; Verify that the root is a real directory.
+    (unless (and root (file-name-absolute-p root))
+      (error "Workspace root '%s' is not an absolute path" root))
     (unless (and root (file-directory-p root))
       (error "Workspace root '%s' is not a valid directory" root))
     root))
@@ -618,7 +632,7 @@ Returns a list of absolute file paths."
          (root-path (macher--workspace-root workspace)))
     (when files-fn
       (let ((files (funcall files-fn workspace-id)))
-        ;; Ensure all paths are absolute
+        ;; Ensure all paths are absolute.
         (when files
           (mapcar
            (lambda (f)
@@ -639,90 +653,86 @@ Returns a workspace information string to be added to the request."
          (workspace-id (cdr workspace))
          (workspace-name (macher--workspace-name workspace))
          (workspace-files (macher--workspace-files workspace))
-         ;; Extract filenames from contexts for comparison.
-         (context-filenames
-          (let (filenames)
+         ;; Extract normalized file paths from contexts for comparison.
+         (context-file-paths
+          (let (file-paths)
             (dolist (context contexts)
               (let ((source (car context)))
                 (when (stringp source)
-                  (push (file-name-nondirectory source) filenames))))
-            filenames)))
+                  (push (file-truename source) file-paths))))
+            file-paths)))
 
     ;; Generate workspace description with context indicators.
     (when workspace-files
-      (with-temp-buffer
-        (insert "WORKSPACE CONTEXT:\n")
-        (insert "=========================\n\n")
-        (insert "IMPORTANT: This workspace contains files you can edit using workspace tools. ")
-        (when (and contexts (> (length contexts) 0))
+      ;; Separate files into two categories based on whether they're in the context.
+      (let ((files-in-context '())
+            (files-available-for-editing '()))
+        (dolist (file-path (sort (copy-sequence workspace-files) #'string<))
+          (let* ((rel-path (file-relative-name file-path (macher--workspace-root workspace)))
+                 (normalized-file-path
+                  (condition-case nil
+                      (file-truename file-path)
+                    (error
+                     file-path)))
+                 (in-context-p (member normalized-file-path context-file-paths)))
+            (if in-context-p
+                (push rel-path files-in-context)
+              (push rel-path files-available-for-editing))))
+
+        ;; Reverse to maintain original sort order.
+        (setq files-in-context (reverse files-in-context))
+        (setq files-available-for-editing (reverse files-available-for-editing))
+
+        (with-temp-buffer
+          (insert "\n")
+          (insert "=======================================================\n")
+          (insert "WORKSPACE CONTEXT:\n")
+          (insert "=======================================================\n")
+          (insert "\n")
           (insert
-           "Files marked with [*] below are already shown in the REQUEST CONTEXT above - "
-           "you do NOT need to read them again."))
-        (insert "\n\n")
-        (insert (format "Workspace: %s\n" workspace-name))
-        (insert
-         (format "Description: In-memory editing environment for '%s' workspace. " workspace-name))
-        (insert "Edit freely using workspace tools. ")
-        (insert "No permissions required - this is a safe virtual editing space.\n\n")
-        (insert "Files in workspace:\n---------\n")
+           "!!! IMPORTANT INFORMATION, READ AND UNDERSTAND THIS SECTION BEFORE USING TOOLS !!!\n")
+          (insert "\n")
+          (insert "The workspace is an in-memory editing environment containing files from ")
+          (insert (format "the user's current project, which is named `%s`.\n" workspace-name))
+          (insert "\n")
+          (insert "ONLY YOU, the LLM, have access to the files in the workspace. You DO NOT ")
+          (insert "need to check for external changes.\n")
+          (insert "\n")
+          (insert "Edit freely using workspace tools. ")
+          (insert "No permissions required - this is a safe virtual editing space.\n")
 
-        (let ((has-context-markers nil))
-          (dolist (file-path (sort (copy-sequence workspace-files) #'string<))
-            (let* ((rel-path (file-relative-name file-path (macher--workspace-root workspace)))
-                   (filename (file-name-nondirectory file-path))
-                   (in-context-p (member filename context-filenames))
-                   (marker
-                    (if in-context-p
-                        "[*] "
-                      "    ")))
-              (when in-context-p
-                (setq has-context-markers t))
-              (insert (format "%s%s\n" marker rel-path))))
+          (when files-in-context
+            (insert "\n")
+            (insert "!!! CRITICAL RULE: DO NOT RE-READ OR SEARCH THESE FILES !!!\n")
+            (insert
+             "Some files' contents have already been provided to you above in the REQUEST CONTEXT.\n")
+            (insert "You MUST NOT re-read or search the contents of these files.\n")
+            (insert "This is wasteful and unnecessary!\n")
 
-          (when has-context-markers
-            (insert "\n[*] = File contents already provided in REQUEST CONTEXT above\n"))
+            (insert "\n")
+            (insert
+             "== Files already provided above (DO NOT use read or search tools on these): ==\n")
+            (dolist (rel-path files-in-context)
+              (insert (format "    %s\n" rel-path))))
+
+          (when files-available-for-editing
+            (insert "\n")
+            (insert
+             (format "%s available for editing:\n"
+                     (if files-in-context
+                         "Other files"
+                       "Files")))
+            (dolist (rel-path files-available-for-editing)
+              (insert (format "    %s\n" rel-path)))
+            (insert "\n"))
+
+          (insert "\n")
+          (insert "=======================================================\n")
+          (insert "END WORKSPACE CONTEXT:\n")
+          (insert "=======================================================\n")
+          (insert "\n")
+
           (buffer-string))))))
-
-(defun macher--insert-file-string (path)
-  "Output information about the file at PATH for the context string.
-
-This behaves similarly to `gptel--insert-file-string', but it includes
-additional information about the file's workspace and its relative path
-from the workspace root.
-
-You might want to use this as follows to add more detailed information
-about files in the default gptel context string (though note the
-internal gptel API is subject to change without warning):
-
-  (advice-add #'gptel--insert-file-string
-              :override #'macher--insert-file-string)
-
-Hopefully at some point there will be a simple way to do this using
-public-facing gptel functionality, without re-implementing the entire
-context string generation."
-  (let* ((file-dir (file-name-directory path))
-         (workspace-info
-          (with-temp-buffer
-            (setq default-directory file-dir)
-            (cl-some #'funcall macher-workspace-functions)))
-         (workspace-path (cdr workspace-info))
-         (relpath
-          (if workspace-info
-              (file-relative-name path workspace-path)
-            (file-name-nondirectory path)))
-         ;; Create description based on workspace context.
-         (description
-          (if workspace-info
-              (format "In file `%s` in workspace `%s`:"
-                      relpath
-                      (macher--workspace-name workspace-info))
-            (format "In file `%s`:" relpath))))
-    ;; Insert the enhanced description.
-    (insert description "\n\n```\n")
-    ;; The rest is just copied from the original function.
-    (insert-file-contents path)
-    (goto-char (point-max))
-    (insert "\n```\n")))
 
 (defun macher--workspace-hash (workspace &optional length)
   "Generate a unique hash for WORKSPACE.
@@ -782,7 +792,7 @@ This function is called automatically when creating action buffers,
 before running the `macher-action-buffer-setup-hook'."
   (pcase macher-action-buffer-ui
     ('basic
-     ;; Basic UI: just hooks
+     ;; Basic UI: just hooks.
      (macher--action-buffer-setup-basic))
     ('default
      ;; Use the global gptel default mode (e.g., markdown-mode)
@@ -832,11 +842,11 @@ It adapts the prompt formatting based on the current major mode."
               ;; Add the action as a tag at the end of the headline.
               (format " :%s:" action-str)
             ""))
-         ;; Extract the first non-whitespace line from the prompt and truncate to fill-column
+         ;; Extract the first non-whitespace line from the prompt and truncate to fill-column.
          (truncated-input
           (let* ((lines (split-string input "\n" t "[[:space:]]*"))
                  (first-line (or (car lines) ""))
-                 ;; Calculate available space: total fill-column minus prefix, action, and spacing
+                 ;; Calculate available space: total fill-column minus prefix, action, and spacing.
                  (prefix (or (alist-get major-mode gptel-prompt-prefix-alist) ""))
                  (used-length (+ (length prefix) (length header-prefix) (length header-postfix)))
                  (available-length (max 10 (- (or fill-column 70) used-length))))
@@ -869,7 +879,7 @@ It adapts the prompt formatting based on the current major mode."
           (when (looking-at "^:PROMPT:")
             (org-cycle)))))
 
-    ;; Enter a selected-buffer context, so we preserve the currently-selected buffer after exiting
+    ;; Enter a selected-buffer context, so we preserve the currently-selected buffer after exiting.
     ;; (since `display-buffer' may change the selected buffer).
     (with-current-buffer (current-buffer)
       (display-buffer (current-buffer)))))
@@ -1056,7 +1066,7 @@ otherwise."
         ;; Set the context directory for operations like diff application or 'project.el'
         ;; lookups.
         (let ((base-dir (macher--workspace-root workspace)))
-          (setq-local default-directory (file-truename base-dir)))))
+          (setq-local default-directory base-dir))))
     (when target-buffer
       (cons target-buffer created-p))))
 
@@ -1138,43 +1148,1198 @@ context won't change before it can edit them."
                       ;; Single-file workspace: only include if it's the exact file.
                       (string= full-path workspace-id)
                     ;; General workspace: include if file is within the workspace root.
-                    (and workspace-root
-                         (string-prefix-p
-                          (file-truename workspace-root) (file-truename full-path))))))
+                    (and workspace-root (string-prefix-p workspace-root full-path)))))
             ;; If this context file is in the workspace, load implementation contents for it.
             (when in-workspace-p
               (macher-context--contents-for-file full-path macher-context))))))))
 
-;; The workspace tools roughly mirror the standard filesystem MCP interface, of which many LLMs
-;; already have some understanding. See
-;; https://github.com/modelcontextprotocol/servers/blob/main/src/filesystem/README.md.
-
 (defun macher--resolve-workspace-path (workspace rel-path)
   "Get the full path for REL-PATH within the WORKSPACE.
-Resolves paths according to workspace type.
-Signals an error if the resolved path is invalid for the current workspace."
-  (let ((workspace-type (car workspace))
-        (workspace-id (cdr workspace)))
-    (unless (consp workspace)
-      (error "Workspace must be a cons cell"))
-    (if (eq workspace-type 'file)
-        ;; Single-file workspace case.
-        (let* ((allowed-file workspace-id))
-          ;; In the single-file workspace, only allow operations on the specific file.
-          (if (string= rel-path (file-name-nondirectory allowed-file))
-              allowed-file
-            (error
-             "In a single-file workspace, only operations on '%s' are allowed, not '%s'"
-             (file-name-nondirectory allowed-file)
-             rel-path)))
-      ;; General workspace case.
-      (let ((workspace-root (macher--workspace-root workspace)))
-        (let ((full-path (expand-file-name rel-path workspace-root))
-              (true-root (file-truename workspace-root)))
-          ;; Verify the resolved path is inside the workspace root.
-          (unless (string-prefix-p true-root (file-truename full-path))
-            (error "Path '%s' resolves outside the workspace" rel-path))
-          full-path)))))
+
+The path will be resolved relative to the workspace root. '.' and '..'
+are handled as standard relative path segments.
+
+Raises an error if the LLM doesn't have permission to interact with the
+path. Specifically, an error is thrown if:
+
+- The path resolves somewhere outside the workspace root, and isn't
+  present in the workspace's files list.
+
+- The path resolves to a file which exists on the filesystem, but isn't
+  present in the workspace's files list (directories beneath the
+  workspace root are allowed).
+
+- The path contains an existing symbolic link as a non-final component
+  below the workspace root - that is, we don't follow allow following
+  directory symlinks within the workspace.
+
+- The path contains an existing file as a non-final component below the
+  workspace root - that is, we don't allow resolving paths that would
+  require treating an existing file as a directory.
+
+Absolute paths are allowed, though the rules above apply to the
+filename, and in practice it would be unexpected for the LLM to pass
+them in.
+
+Note also that paths outside the workspace root are allowed _if_ they
+appear in the workspace's files list. This won't be the case for the
+built-in workspace types, but might be relevant for custom workspace
+types."
+  (let* (
+         ;; We don't really want to deal with the `file-truename', as this would resolve symlinks
+         ;; and might mess up the path structure when dealing with relative paths like
+         ;; "../sibling-dir-in-custom-workspace/". However, we will be using `expand-file-name' to
+         ;; resolve the path, which expands some path components like "~" into real directories -
+         ;; so, in order to more easily check whether the resolved path is inside the workspace
+         ;; root, we expand these components immediately.
+         (workspace-root (expand-file-name (macher--workspace-root workspace)))
+         ;; Resolve the path relative to workspace root, handling . and ..
+         (full-path (expand-file-name rel-path workspace-root)))
+
+    ;; Check for files or symlinks in non-final path components below the workspace root
+    ;; Only perform this check for paths that are within the workspace directory - other files
+    (when (string-prefix-p workspace-root full-path)
+      (let* ((relative-path (file-relative-name full-path workspace-root))
+             ;; Use file-name-split for OS-independent path component splitting.
+             (path-components (file-name-split relative-path))
+             (current-path workspace-root))
+        ;; Check each component except the last one for files or symlinks (only below workspace
+        ;; root).
+        (when (> (length path-components) 1)
+          (dolist (component (butlast path-components))
+            (unless (string-empty-p component) ; Skip empty components
+              (setq current-path (expand-file-name component current-path))
+              (when (file-exists-p current-path)
+                (cond
+                 ((file-symlink-p current-path)
+                  (error "Path '%s' contains a symbolic link in a non-final component" rel-path))
+                 ((not (file-directory-p current-path))
+                  (error "Path '%s' contains a file in a non-final component" rel-path)))))))))
+
+    ;; Validate access permissions.
+    (let* ((raw-workspace-files (macher--workspace-files workspace))
+           ;; Process workspace files by expanding them relative to workspace root
+           (workspace-files
+            (when raw-workspace-files
+              (mapcar
+               (lambda (file-path)
+                 (if (file-name-absolute-p file-path)
+                     file-path
+                   (expand-file-name file-path workspace-root)))
+               raw-workspace-files)))
+           (is-outside-workspace
+            (not
+             (or
+              ;; Check whether the path is equal to the workspace root, i.e. '.'.
+              (string= (directory-file-name workspace-root) full-path)
+              ;; Check whether the path begins with the workspace root + the path separator.
+              (string-prefix-p (file-name-as-directory workspace-root) full-path))))
+           (file-exists (file-exists-p full-path)))
+
+      (when (and is-outside-workspace (not (member full-path workspace-files)))
+        (error "Path '%s' resolves outside the workspace" rel-path))
+
+      (when (and file-exists
+                 ;; Allow directories, but only within the workspace.
+                 (or is-outside-workspace (not (file-directory-p full-path)))
+                 (not (member full-path workspace-files)))
+        (error "File '%s' is not in the workspace files list" rel-path)))
+
+    ;; Return the resolved path
+    full-path))
+
+(defun macher--format-size (bytes)
+  "Format BYTES as a human-readable size string."
+  (let ((units '("B" "KB" "MB" "GB" "TB"))
+        (size (float bytes))
+        (unit-index 0))
+    (while (and (>= size 1024) (< unit-index (1- (length units))))
+      (setq size (/ size 1024.0))
+      (setq unit-index (1+ unit-index)))
+    (if (= unit-index 0)
+        (format "%d %s" (truncate size) (nth unit-index units))
+      (format "%.1f %s" size (nth unit-index units)))))
+
+(defun macher--read-string (content &optional offset limit show-line-numbers)
+  "Read string CONTENT with optional line-number OFFSET and LIMIT.
+
+- CONTENT is the full string content to read from.
+
+- OFFSET, if provided, specifies the line number to start reading
+  from (1-based). For negative values, starts at that many lines before
+  the end of the file.
+
+- LIMIT, if provided, specifies the number of lines to read from the
+  start position. For negative values, the actual limit is computed as
+  (total_lines + limit). For example, with a 100-line file: limit=10
+  reads 10 lines, limit=-10 reads 90 lines (100 + (-10)).
+
+- SHOW-LINE-NUMBERS, if non-nil, formats output in cat -n style with
+  line numbers. Lines are formatted as \"[spaces for alignment][line
+  number][tab][line content]\".
+
+If neither OFFSET nor LIMIT is provided, returns the full content.
+
+If only OFFSET is provided, returns content from that line to the end.
+
+If only LIMIT is provided, returns the first LIMIT lines.
+
+If both are provided, returns LIMIT lines starting from OFFSET.
+
+Returns the processed content as a string."
+  (if (and (not offset) (not limit) (not show-line-numbers))
+      ;; Return full content if no parameters provided.
+      content
+    (let* ((lines (split-string content "\n"))
+           (num-lines (length lines))
+           (start-idx
+            (if offset
+                (cond
+                 ;; Negative offset: start at that many lines before the end.
+                 ((< offset 0)
+                  (max 0 (+ num-lines offset)))
+                 ;; Zero or positive offset: 1-based indexing (treat 0 as 1).
+                 (t
+                  (max 0 (min (1- (max 1 offset)) num-lines))))
+              0))
+           (actual-limit
+            (when limit
+              (cond
+               ;; Negative limit: equivalent to total lines - (negative limit value).
+               ((< limit 0)
+                (max 0 (+ num-lines limit)))
+               ;; Zero or positive limit: use as-is.
+               (t
+                limit))))
+           (end-idx
+            (if actual-limit
+                (min num-lines (+ start-idx actual-limit))
+              num-lines))
+           (selected-lines (seq-subseq lines start-idx end-idx)))
+      (cond
+       (show-line-numbers
+        ;; Format with line numbers (cat -n style).
+        (let* ((actual-start-line (1+ start-idx))
+               ;; `cat -n` includes the trailing newline if present, but doesn't number it. We
+               ;; handle this as a special case. If:
+               ;;
+               ;; - the last line is empty
+               ;; - we're looking at the actual last line of the content (i.e. not a blank line in
+               ;;   the middle)
+               ;; - there's more than one line (since `cat -n` on a completely blank file does show
+               ;;   line number 1
+               ;;
+               ;; then exclude the last line from the list of lines to be numbered, and add it back
+               ;; at the end.
+               (should-exclude-final-empty
+                (and (= end-idx num-lines) ; processing to end.
+                     (> (length selected-lines) 1) ; we have more than one line.
+                     (string-empty-p (car (last selected-lines))))) ; last line is empty.
+               (lines-to-number
+                (if should-exclude-final-empty
+                    (butlast selected-lines)
+                  selected-lines))
+               (max-line-num (+ actual-start-line (length lines-to-number) -1))
+               (line-num-width
+                (if (> (length lines-to-number) 0)
+                    (length (number-to-string max-line-num))
+                  1))
+               (formatted-lines
+                (cl-loop
+                 for
+                 line
+                 in
+                 lines-to-number
+                 for
+                 line-num
+                 from
+                 actual-start-line
+                 collect
+                 (format (concat "%" (number-to-string line-num-width) "d\t%s") line-num line)))
+               (result (string-join formatted-lines "\n")))
+          ;; Add the final trailing newline if we excluded the final empty line
+          (if should-exclude-final-empty
+              (concat result "\n")
+            result)))
+       ;; Regular format without line numbers.
+       (t
+        (string-join selected-lines "\n"))))))
+
+(defun macher--with-workspace-file (context path callback &optional set-dirty-p)
+  "Helper function to execute CALLBACK with workspace file content.
+
+CONTEXT is a `macher-context' struct containing workspace information.
+
+PATH is the path to the file, relative to the workspace root.
+
+CALLBACK is called with arguments (full-path new-content) where:
+- full-path is the absolute path to the file
+- new-content is the current content string of the file
+
+If SET-DIRTY-P is non-nil, sets the dirty-p flag on the context."
+  (let* ((workspace (macher-context-workspace context))
+         (resolve-workspace-path (apply-partially #'macher--resolve-workspace-path workspace))
+         (get-or-create-file-contents
+          (lambda (file-path)
+            "Get or create implementation contents for FILE-PATH, scoped to the current request.
+Returns a cons cell (orig-content . new-content) of strings for the file.
+Also updates the context's :contents alist."
+            (let ((full-path (funcall resolve-workspace-path file-path)))
+              (macher-context--contents-for-file full-path context))))
+         (full-path (funcall resolve-workspace-path path))
+         ;; Get implementation contents for this file.
+         (contents (funcall get-or-create-file-contents path))
+         (new-content (cdr contents)))
+    ;; Check if the file exists for editing.
+    (if (not new-content)
+        (error (format "File '%s' not found in workspace" path))
+      ;; Set the dirty flag to indicate changes are being made if requested.
+      (when set-dirty-p
+        (setf (macher-context-dirty-p context) t))
+      ;; Call the callback with the file content.
+      (funcall callback full-path new-content))))
+
+;; The workspace tools are somewhat inspired by the reference filesystem MCP. See
+;; https://github.com/modelcontextprotocol/servers/blob/main/src/filesystem/README.md.
+
+(defun macher--tool-read-file (context path &optional offset limit show-line-numbers)
+  "Read the contents of a file specified by PATH within the workspace.
+
+CONTEXT is a `macher-context' struct containing workspace information.
+
+PATH is the path to the file, relative to the workspace root.
+
+OFFSET, if provided, specifies the line number to start reading
+from (1-based).
+
+LIMIT, if provided, specifies the number of lines to read.
+
+SHOW-LINE-NUMBERS, if non-nil, formats output in cat -n style with line numbers.
+
+Returns the file contents as a string, with optional
+offset/limit/show-line-numbers processing. For symlinks, returns the target
+path instead of following the link. Signals an error if the file is not
+found in the workspace."
+  (let* ((workspace (macher-context-workspace context))
+         (resolve-workspace-path (apply-partially #'macher--resolve-workspace-path workspace))
+         (full-path (funcall resolve-workspace-path path)))
+
+    ;; Check if this is a symlink first (only for existing files).
+    (if (file-symlink-p full-path)
+        ;; For symlinks, return the target path instead of following the link.
+        (let ((target (file-symlink-p full-path)))
+          (format "Symlink target: %s" target))
+
+      ;; Normal/non-symlink handling.
+      (macher--with-workspace-file
+       context
+       path
+       (lambda (_full-path new-content)
+         ;; Some LLMs (for example qwen3-coder at time of writing) seem to have trouble invoking
+         ;; tools with integer inputs - they'll always pass e.g. '1.0' instead of '1'. Therefore we
+         ;; need to support float inputs, which in general we handle by rounding to the nearest
+         ;; integer.
+         (let* ((parsed-offset
+                 (when offset
+                   (round offset)))
+                (parsed-limit
+                 (when limit
+                   (round limit)))
+                (processed-content
+                 (macher--read-string new-content parsed-offset parsed-limit show-line-numbers)))
+           ;; Check if the processed content exceeds the maximum read length.
+           (when (> (length processed-content) macher--max-read-length)
+             (error
+              "File content too large: %d bytes exceeds maximum read length of %d bytes"
+              (length processed-content)
+              macher--max-read-length))
+           processed-content))
+       nil))))
+
+(defun macher--tool-list-directory (context path &optional recursive sizes)
+  "List directory contents at PATH within the workspace.
+
+CONTEXT is a `macher-context' struct containing workspace information.
+
+PATH is the path to the directory, relative to the workspace root.
+
+RECURSIVE, if non-nil, recursively lists subdirectories.
+
+SIZES, if non-nil, includes file sizes in the output.
+
+Returns a formatted string listing the directory contents. Files are
+prefixed with 'file:' and directories with 'dir:' to be clear to LLMs.
+Signals an error if the directory is not found in the workspace."
+  (let* ((workspace (macher-context-workspace context))
+         (resolve-workspace-path (apply-partially #'macher--resolve-workspace-path workspace))
+         (full-path (funcall resolve-workspace-path path))
+         (workspace-root (macher--workspace-root workspace))
+         (results '())
+         (context-contents (macher-context-contents context)))
+
+    ;; Check if this path exists as a file in our context (would indicate it's not a directory).
+    (when-let ((existing-entry (assoc (macher--normalize-path full-path) context-contents)))
+      (let ((contents (cdr existing-entry)))
+        ;; Has new-content, so it's a file.
+        (when (cdr contents)
+          (error (format "Path '%s' is a file, not a directory" path)))))
+
+    ;; Check if the directory exists on disk OR has files in the context.
+    ;; A directory is considered to exist if:
+    ;; 1. It exists on disk as a directory, OR
+    ;; 2. There are files in the context that have this directory as a parent
+    (let ((directory-has-context-files-p
+           (cl-some
+            (lambda (entry)
+              (let* ((file-path (car entry))
+                     (contents (cdr entry))
+                     (new-content (cdr contents)))
+                ;; Only consider files that have new content (not deleted files)
+                (when new-content
+                  (let ((file-dir (file-name-directory file-path)))
+                    ;; Check if this file's directory is or is a subdirectory of the requested path
+                    (string-prefix-p
+                     (file-name-as-directory full-path) (file-name-as-directory file-dir))))))
+            context-contents)))
+      (unless (or (file-directory-p full-path) directory-has-context-files-p)
+        (error (format "Directory '%s' not found in workspace" path))))
+
+    ;; Helper function to check if a file is deleted in the context.
+    (cl-labels
+        ((file-deleted-in-context-p
+          (file-path) "Check if FILE-PATH is marked as deleted in the context."
+          (when-let ((entry (assoc (macher--normalize-path file-path) context-contents)))
+            (let ((contents (cdr entry)))
+              (and
+               ;; Has original content...
+               (car contents)
+               ;; ...but no new content.
+               (not (cdr contents))))))
+
+         (get-file-content-size
+          (file-path) "Get the size of FILE-PATH, considering context modifications."
+          (if-let ((entry (assoc (macher--normalize-path file-path) context-contents)))
+            (let* ((contents (cdr entry))
+                   (new-content (cdr contents)))
+              (if new-content
+                  (length new-content)
+                ;; File is deleted in context, so size is 0.
+                0))
+            ;; Not in context, get size from disk.
+            (if (file-exists-p file-path)
+                (file-attribute-size (file-attributes file-path))
+              0)))
+
+         (collect-new-context-files
+          (current-path)
+          "Collect files that exist only in context (newly created) under CURRENT-PATH."
+          (let ((new-files '()))
+            (dolist (entry context-contents)
+              (let* ((file-path (car entry))
+                     (contents (cdr entry))
+                     (orig-content (car contents))
+                     (new-content (cdr contents)))
+                ;; This is a newly created file if it has new-content but no orig-content.
+                (when (and new-content (not orig-content))
+                  ;; Check if this file is a direct child of the current directory.
+                  (let ((file-dir (file-name-directory file-path))
+                        (normalized-current-path (file-name-as-directory current-path)))
+                    (when (string= (file-name-as-directory file-dir) normalized-current-path)
+                      (push (file-name-nondirectory file-path) new-files))))))
+            new-files))
+
+         (collect-new-context-directories
+          (current-path)
+          "Collect directory names that are implied by context files under CURRENT-PATH."
+          (let ((new-dirs '()))
+            (dolist (entry context-contents)
+              (let* ((file-path (car entry))
+                     (contents (cdr entry))
+                     (new-content (cdr contents)))
+                ;; Only consider files that have new content (not deleted files).
+                (when new-content
+                  ;; Check if this file creates any intermediate directories under current-path.
+                  (let* ((relative-path
+                          (file-relative-name file-path (file-name-as-directory current-path))))
+                    ;; Only process if the file is actually under the current path (not ..).
+                    (when (not (string-prefix-p ".." relative-path))
+                      ;; Split the path to find the first directory component
+                      (when (string-match "/" relative-path)
+                        (let ((first-component
+                               (substring relative-path 0 (match-beginning 0))))
+                          (unless (or (string-empty-p first-component)
+                                      (member first-component new-dirs))
+                            (push first-component new-dirs)))))))))
+            new-dirs))
+
+         (collect-entries
+          (current-path current-rel-path depth)
+          ;; Get all entries from the directory (if it exists on disk) plus any context files.
+          (let* ((workspace-files (macher--workspace-files workspace))
+                 ;; Only include disk entries that are in the workspace files list.
+                 (disk-entries
+                  (if (file-directory-p current-path)
+                      (let ((all-disk-files (directory-files current-path nil "^[^.]")))
+                        (cl-remove-if-not
+                         (lambda (entry)
+                           (let ((entry-full-path (expand-file-name entry current-path)))
+                             ;; Include if it's in the workspace files list OR it's a directory.
+                             (or (cl-some
+                                  (lambda (workspace-file)
+                                    ;; Handle both absolute and relative paths in workspace-files.
+                                    (let ((normalized-workspace-file
+                                           (if (file-name-absolute-p workspace-file)
+                                               workspace-file
+                                             (expand-file-name workspace-file workspace-root))))
+                                      (string= entry-full-path normalized-workspace-file)))
+                                  workspace-files)
+                                 (file-directory-p entry-full-path))))
+                         all-disk-files))
+                    '()))
+                 ;; Add any newly created files from the context.
+                 (context-new-files (collect-new-context-files current-path))
+                 ;; Add any directories implied by context files.
+                 (context-new-directories (collect-new-context-directories current-path))
+                 ;; Combine and deduplicate.
+                 (all-entries
+                  (cl-remove-duplicates
+                   (append disk-entries context-new-files context-new-directories)
+                   :test #'string=)))
+            ;; Process entries if we have any entries to process.
+            (when (> (length all-entries) 0)
+              (dolist (entry all-entries)
+                (let* ((entry-full-path (expand-file-name entry current-path))
+                       (entry-rel-path
+                        (if (string-empty-p current-rel-path)
+                            entry
+                          (concat current-rel-path "/" entry)))
+                       (entry-deleted-p (file-deleted-in-context-p entry-full-path))
+                       (entry-exists-on-disk-p (file-exists-p entry-full-path))
+                       (entry-is-symlink-p
+                        (and (not entry-deleted-p) (file-symlink-p entry-full-path)))
+                       (entry-exists-in-context-p
+                        (when-let ((entry
+                                    (assoc
+                                     (macher--normalize-path entry-full-path) context-contents)))
+                          (let ((contents (cdr entry)))
+                            ;; Has new content.
+                            (cdr contents))))
+                       (entry-exists-p
+                        (or entry-exists-on-disk-p
+                            entry-exists-in-context-p entry-is-symlink-p
+                            ;; Also exists if it's a directory implied by context files.
+                            (member entry context-new-directories)))
+                       (entry-is-dir-p
+                        (and entry-exists-p
+                             (not entry-deleted-p) (not entry-is-symlink-p)
+                             ;; A path is a directory if it exists on disk as a directory OR if it's
+                             ;; in our context-new-directories list.
+                             (or (file-directory-p entry-full-path)
+                                 (member entry context-new-directories))))
+                       (size-info "")
+                       (indent (make-string (* depth 2) ?\s)))
+
+                  ;; Skip deleted files.
+                  (unless entry-deleted-p
+                    ;; Get size information if requested (not for directories or symlinks).
+                    (when (and sizes (not entry-is-dir-p) (not entry-is-symlink-p))
+                      (let ((file-size (get-file-content-size entry-full-path)))
+                        (setq size-info (format " (%s)" (macher--format-size file-size)))))
+
+                    ;; Add symlink target info if it's a symlink.
+                    (when entry-is-symlink-p
+                      (let ((target (file-symlink-p entry-full-path)))
+                        (setq size-info (format " -> %s" target))))
+
+                    ;; Add entry to results.
+                    (push (format "%s%s: %s%s"
+                                  indent
+                                  (cond
+                                   (entry-is-symlink-p
+                                    "link")
+                                   (entry-is-dir-p
+                                    "dir")
+                                   (t
+                                    "file"))
+                                  entry-rel-path size-info)
+                          results)
+
+                    ;; Recurse into subdirectories if requested (but not into symlinked
+                    ;; directories).
+                    (when (and recursive entry-is-dir-p)
+                      (collect-entries entry-full-path entry-rel-path (1+ depth))))))))))
+
+      ;; Start collection.
+      (collect-entries full-path "" 0))
+
+    ;; Return formatted results.
+    (if results
+        (string-join (reverse results) "\n")
+      "Directory is empty")))
+
+(defun macher--tool-edit-file (context path old-text new-text &optional replace-all)
+  "Edit file specified by PATH within the workspace.
+
+CONTEXT is a `macher-context' struct containing workspace information.
+
+PATH is the path to the file, relative to the workspace root.
+
+OLD-TEXT is the exact text to replace.
+
+NEW-TEXT is the replacement text.
+
+REPLACE-ALL, if non-nil, replaces all occurrences; otherwise errors if
+multiple matches exist.
+
+Returns nil on success. Signals an error if the file is not found or if
+the edit operation fails. Sets the dirty-p flag on the context to
+indicate changes."
+  ;; Handle :json-false inputs for replace-all parameter.
+  (let ((replace-all (and replace-all (not (eq replace-all :json-false)))))
+    ;; Validate required parameters
+    (unless (and old-text new-text)
+      (error "Both old_text and new_text are required"))
+    ;; Use the helper function to perform the edit.
+    (macher--with-workspace-file context path
+                                 (lambda (full-path new-content)
+                                   (let ((result
+                                          (macher--edit-string new-content old-text new-text
+                                                               replace-all)))
+                                     ;; Update the content in the context.
+                                     (macher-context--set-new-content-for-file
+                                      full-path result context)
+                                     ;; Return nil to indicate success.
+                                     nil))
+                                 t)))
+
+(defun macher--tool-multi-edit-file (context path edits)
+  "Make multiple edits to a file specified by PATH within the workspace.
+
+CONTEXT is a `macher-context' struct containing workspace information.
+
+PATH is the path to the file, relative to the workspace root.
+
+EDITS is a vector of edit operations, each containing :old_string and
+:new_string. For compatibility with LLMs that don't support array
+arguments, a JSON string representing an array is also accepted.
+
+All edits are applied in sequence to the same file. Each edit requires
+exact whitespace matching. If any edit fails, the entire operation
+fails.
+
+Returns nil on success. Signals an error if the file is not found or if
+any edit operation fails. Sets the dirty-p flag on the context to
+indicate changes."
+  ;; Validate that edits is a vector, i.e. a JSON array. Ideally the argument should
+  ;; have been sent as an actual array, but some LLMs seem to have trouble with this,
+  ;; and instead send JSON strings which decode to an array. Allow both cases, as
+  ;; although the string case technically violates the tool signature, we can still
+  ;; handle it unambiguously.
+  (unless (vectorp edits)
+    (if (stringp edits)
+        ;; Try to decode JSON string to vector.
+        (condition-case nil
+            (let ((decoded (json-parse-string edits :array-type 'vector :object-type 'plist)))
+              (if (vectorp decoded)
+                  (setq edits decoded)
+                (error
+                 "The 'edits' parameter must be an array, but the decoded JSON is not an array")))
+          (error
+           (error
+            "The 'edits' parameter must be an array of objects, or a valid JSON string representing an array")))
+      ;; Not a vector or string - invalid input.
+      (error "The 'edits' parameter must be an array of objects, not %s" (type-of edits))))
+  ;; Use the helper function to perform the edits.
+  (macher--with-workspace-file context path
+                               (lambda (full-path new-content)
+                                 ;; Apply edits sequentially.
+                                 (cl-loop
+                                  for edit across edits do
+                                  (let ((old-text (plist-get edit :old_text))
+                                        (new-text (plist-get edit :new_text))
+                                        (replace-all (plist-get edit :replace_all)))
+
+                                    (unless (and old-text new-text)
+                                      (error
+                                       "Each edit must contain old_text and new_text properties"))
+                                    ;; Handle :json-false inputs for replace-all parameter.
+                                    (setq replace-all
+                                          (and replace-all (not (eq replace-all :json-false))))
+                                    (setq new-content
+                                          (macher--edit-string new-content old-text new-text
+                                                               replace-all))
+                                    ;; Update the content in the context after each edit.
+                                    (macher-context--set-new-content-for-file
+                                     full-path new-content context)))
+                                 ;; Return nil to indicate success.
+                                 nil)
+                               t))
+
+(defun macher--tool-write-file (context path content)
+  "Create a new file or completely overwrite an existing file with CONTENT.
+
+CONTEXT is a `macher-context' struct containing workspace information.
+
+PATH is the path to the file, relative to the workspace root.
+
+CONTENT is the complete new content for the file.
+
+Use with caution as it will overwrite existing files without warning.
+Handles text content with proper encoding.
+
+Returns nil on success. Sets the dirty-p flag on the context to indicate changes."
+  (let* ((workspace (macher-context-workspace context))
+         (resolve-workspace-path (apply-partially #'macher--resolve-workspace-path workspace))
+         (full-path (funcall resolve-workspace-path path)))
+    ;; Set the dirty flag to indicate changes are being made.
+    (setf (macher-context-dirty-p context) t)
+    ;; Set the new content in the context (this will create the entry if needed).
+    (macher-context--set-new-content-for-file full-path content context)
+    nil))
+
+(defun macher--tool-move-file (context source-path destination-path)
+  "Move or rename files within the workspace.
+
+CONTEXT is a `macher-context' struct containing workspace information.
+
+SOURCE-PATH is the source path relative to the workspace root.
+
+DESTINATION-PATH is the destination path relative to the workspace root.
+
+Can move files between directories and rename them in a single operation.
+If the destination exists, the operation will fail. Works across different
+directories and can be used for simple renaming within the same directory.
+
+Returns nil on success. Signals an error if the source file is not found or
+if the destination already exists. Sets the dirty-p flag on the context to
+indicate changes."
+  (let* ((workspace (macher-context-workspace context))
+         (resolve-workspace-path (apply-partially #'macher--resolve-workspace-path workspace))
+         (dest-full-path (funcall resolve-workspace-path destination-path)))
+    ;; Check if destination already exists.
+    (let ((dest-contents (macher-context--contents-for-file dest-full-path context)))
+      (when (cdr dest-contents)
+        (error (format "Destination '%s' already exists" destination-path))))
+    ;; Use the helper function to move the file.
+    (macher--with-workspace-file context source-path
+                                 (lambda (source-full-path source-new-content)
+                                   ;; Copy content from source to destination.
+                                   (macher-context--set-new-content-for-file
+                                    dest-full-path source-new-content context)
+                                   ;; Mark source for deletion by setting its content to nil.
+                                   (macher-context--set-new-content-for-file
+                                    source-full-path nil context)
+                                   ;; Return nil to indicate success.
+                                   nil)
+                                 t)))
+
+(defun macher--tool-delete-file (context rel-path)
+  "Delete a file specified by REL-PATH within the workspace.
+
+CONTEXT is a `macher-context' struct containing workspace information.
+
+REL-PATH is the path to the file, relative to the workspace root.
+
+The file must exist and will be marked for deletion in the patch.
+Permanently removes the file from the workspace.
+
+Returns nil on success. Signals an error if the file is not found.
+Sets the dirty-p flag on the context to indicate changes."
+  ;; Use the helper function to delete the file.
+  (macher--with-workspace-file context rel-path
+                               (lambda (full-path _editable-content)
+                                 ;; For deletion, set the new content to nil to indicate deletion.
+                                 (macher-context--set-new-content-for-file full-path nil context)
+                                 ;; Return nil to indicate success.
+                                 nil)
+                               t))
+
+(cl-defun macher--search-get-xref-matches (context pattern &key path file-regexp case-insensitive)
+  "Get raw xref matches as an alist of ((filename . matches)).
+
+CONTEXT is the macher-context, which will be taken into account when
+searching for matches (including new and deleted files).
+
+PATTERN is the regexp pattern to search for.
+
+PATH is the directory or file to search, defaulting to the context's
+workspace root.
+
+FILE-REGEXP is a regexp to specify which files should be included - it
+will be matched against each file's path relative to the search PATH.
+
+CASE-INSENSITIVE, if non-nil, performs a case-insensitive search.
+
+The search will be performed using `xref-matches-in-files', which uses
+the 'xref-search-program' to perform the search.
+
+Returns matches-alist with structure ((rel-path . (xref-match-item1 xref-match-item2 ...)) ...)."
+  (require 'xref)
+  (let* (
+         ;; Set case-fold-search to enable case-insensitive search when needed. Note: xref uses
+         ;; `grep-expand-template' to generate the command, which performs a case-insensitive search
+         ;; if/only if `case-fold-search' is truthy and `isearch-no-upper-case-p' is true for the
+         ;; regexp in question.
+         (case-fold-search case-insensitive)
+         (workspace (macher-context-workspace context))
+         (workspace-root (macher--workspace-root workspace))
+         (resolve-workspace-path (apply-partially #'macher--resolve-workspace-path workspace))
+         (search-path (funcall resolve-workspace-path (or path ".")))
+         (context-contents (macher-context-contents context))
+         (workspace-files (macher--workspace-files workspace))
+         (path
+          (when path
+            (expand-file-name path workspace-root)))
+         ;; When case-insensitive is true, downcase the pattern so that `isearch-no-upper-case-p'
+         ;; returns true, which is required for grep's case-insensitive mode to activate.
+         (search-pattern
+          (if case-insensitive
+              (downcase pattern)
+            pattern))
+         (temp-files-alist '())
+         (results '()))
+
+    (let* (
+           ;; Create a list of files to search, filtering by path and glob.
+           (files-to-search
+            (cl-remove-if-not
+             (lambda (file-path)
+               (let ((full-path (expand-file-name file-path workspace-root)))
+                 (and
+                  ;; File is under the search path.
+                  (string-prefix-p search-path full-path)
+                  ;; File matches regexp if specified.
+                  (if file-regexp
+                      (let ((rel-path
+                             (if path
+                                 (file-relative-name full-path search-path)
+                               (file-relative-name full-path workspace-root))))
+                        (string-match-p file-regexp rel-path))
+                    t)
+                  ;; File exists or has content in context.
+                  (or (file-exists-p full-path)
+                      (let ((entry (assoc (macher--normalize-path full-path) context-contents)))
+                        (and entry (cdr (cdr entry))))))))
+             workspace-files))
+           ;; Add any context-only files that match our criteria.
+           (context-only-files
+            (cl-remove-if-not
+             (lambda (entry)
+               (let* ((file-path (car entry))
+                      (contents (cdr entry))
+                      (orig-content (car contents))
+                      (new-content (cdr contents)))
+                 (and
+                  ;; File has new content (not deleted).
+                  new-content
+                  ;; File is not already in workspace-files.
+                  (not
+                   (cl-find
+                    file-path
+                    files-to-search
+                    :test (lambda (a b) (string= a (expand-file-name b workspace-root)))))
+                  ;; File is under search path.
+                  (string-prefix-p search-path file-path)
+                  ;; File matches regexp if specified.
+                  (if file-regexp
+                      (let ((rel-path
+                             (if path
+                                 (file-relative-name file-path search-path)
+                               (file-relative-name file-path workspace-root))))
+                        (string-match-p file-regexp rel-path))
+                    t))))
+             context-contents))
+           ;; Combine and convert to absolute paths
+           (all-files-to-search
+            (append
+             (mapcar
+              (lambda (f)
+                (if (file-name-absolute-p f)
+                    f
+                  (expand-file-name f workspace-root)))
+              files-to-search)
+             (mapcar #'car context-only-files))))
+
+      ;; Create temporary files for context modifications.
+      (setq all-files-to-search
+            (mapcar
+             (lambda (file-path)
+               (let ((entry (assoc (macher--normalize-path file-path) context-contents)))
+                 (if entry
+                     (let* ((contents (cdr entry))
+                            (new-content (cdr contents)))
+                       (if new-content
+                           ;; Create temp file with modified content.
+                           (let ((temp-file (make-temp-file "macher-search")))
+                             (with-temp-buffer
+                               (insert new-content)
+                               (write-region (point-min) (point-max) temp-file nil 'silent))
+                             (push (cons temp-file file-path) temp-files-alist)
+                             temp-file)
+                         ;; File is deleted in context, skip it.
+                         nil))
+                   ;; No context modification, use original file.
+                   file-path)))
+             all-files-to-search))
+
+      ;; Remove nil entries (deleted files).
+      (setq all-files-to-search (cl-remove-if #'null all-files-to-search))
+
+      ;; Use xref-matches-in-files to search and clean up temp files afterwards.
+      (unwind-protect
+          (progn
+            (when all-files-to-search
+              (let* ((xref-matches (xref-matches-in-files search-pattern all-files-to-search)))
+                (dolist (match xref-matches)
+                  (let*
+                      ((location (xref-item-location match))
+                       (file-path (xref-file-location-file location))
+                       ;; Map temp file back to original file.
+                       (original-file (or (cdr (assoc file-path temp-files-alist)) file-path))
+                       ;; Ensure matched files are loaded into the macher-context, so their contents
+                       ;; won't change before they're accessed.
+                       (_ (macher-context--contents-for-file original-file context))
+                       ;; Always show results relative to workspace root (like grep relative to
+                       ;; cwd). Special case: if path points to a specific file, show the original
+                       ;; path parameter.
+                       (rel-path
+                        (if (and path
+                                 (file-exists-p search-path)
+                                 (not (file-directory-p search-path)))
+                            ;; Path is a specific file, use the original path parameter.
+                            path
+                          ;; Otherwise, always relative to workspace root.
+                          (file-relative-name original-file workspace-root))))
+
+                    ;; Group results by file for proper formatting.
+                    (let ((file-entry (assoc rel-path results)))
+                      (if file-entry
+                          ;; Add to the existing file's match list - file-entry structure is
+                          ;; (rel-path . xref-match-item-list).
+                          (setcdr file-entry (cons match (cdr file-entry)))
+                        ;; Create new file entry - structure is (rel-path . xref-match-item-list).
+                        (push (cons rel-path (list match)) results)))))))
+
+            ;; Return just the results - temp files are cleaned up in the unwind-protect.
+            results)
+
+        ;; Cleanup: delete temporary files.
+        (dolist (temp-entry temp-files-alist)
+          (when (file-exists-p (car temp-entry))
+            (delete-file (car temp-entry)))))
+
+      results)))
+
+(defun macher--search-format-files-mode (matches-alist)
+  "Format search results for files mode output.
+
+MATCHES-ALIST has structure ((rel-path . (xref-match-item1 xref-match-item2 ...)) ...)."
+  (let ((output "")
+        (total-matches
+         (apply #'+ (mapcar (lambda (file-entry) (length (cdr file-entry))) matches-alist))))
+    ;; Files mode: show file paths with match counts
+    (dolist (file-entry (reverse matches-alist))
+      (let ((file-path (car file-entry))
+            (matches (cdr file-entry)))
+        (setq output
+              (concat
+               output
+               (format "%s (%d %s)\n"
+                       file-path (length matches)
+                       (if (= (length matches) 1)
+                           "match"
+                         "matches"))))))
+    (when matches-alist
+      (setq output
+            (concat
+             output
+             (format "\nTotal: %d %s in %d %s"
+                     total-matches
+                     (if (= total-matches 1)
+                         "match"
+                       "matches")
+                     (length matches-alist)
+                     (if (= (length matches-alist) 1)
+                         "file"
+                       "files")))))
+    output))
+
+(defun macher--search-format-content-mode
+    (context matches-alist lines-before lines-after show-line-numbers)
+  "Format search results for content mode output.
+
+CONTEXT is the macher-context struct.
+
+LINES-BEFORE and LINES-AFTER specify additional lines of context to
+include.
+
+SHOW-LINE-NUMBERS toggles inclusion of line numbers in the output.
+
+MATCHES-ALIST has structure ((rel-path . (xref-match-item1 xref-match-item2 ...)) ...)."
+  (let* ((workspace (macher-context-workspace context))
+         (workspace-root (macher--workspace-root workspace))
+         (context-contents (macher-context-contents context))
+         (output ""))
+
+    ;; Content mode: show matching lines with grep-like format.
+    (dolist (file-entry (reverse matches-alist))
+      (let* ((file-path (car file-entry))
+             (matches (reverse (cdr file-entry))))
+
+        ;; For content mode with context lines, we need to read the file content.
+        (let* ((original-file (expand-file-name file-path workspace-root))
+               (entry (assoc (macher--normalize-path original-file) context-contents))
+               (file-content
+                (if entry
+                    ;; File is in context, use the current content (new-content). Note: deleted
+                    ;; files (where new-content is nil) are filtered out during the search phase, so
+                    ;; we should never encounter them here, but it doesn't really matter if we do -
+                    ;; we'll just have nil file-content in that case.
+                    (cdr (cdr entry))
+                  ;; File not in context, read from disk.
+                  (when (file-exists-p original-file)
+                    (with-temp-buffer
+                      (insert-file-contents original-file)
+                      (buffer-substring-no-properties (point-min) (point-max))))))
+               (lines
+                (when file-content
+                  (split-string file-content "\n")))
+               (has-context (or lines-before lines-after)))
+
+          (if (and lines has-context)
+              ;; Context mode: merge overlapping ranges and show continuous output.
+              (let* ((line-ranges '())
+                     (match-lines-set (make-hash-table :test 'eq)))
+                ;; First, collect all match line numbers in a hash set for quick lookup.
+                (dolist (match matches)
+                  (puthash (xref-file-location-line (xref-item-location match)) t match-lines-set))
+
+                ;; Calculate line ranges for each match (including context)
+                (dolist (match matches)
+                  (let* ((line-num (xref-file-location-line (xref-item-location match)))
+                         (start-line (max 1 (- line-num (or lines-before 0))))
+                         (end-line (min (length lines) (+ line-num (or lines-after 0)))))
+                    (push (list start-line end-line) line-ranges)))
+
+                ;; Sort ranges by start line.
+                (setq line-ranges (sort line-ranges (lambda (a b) (< (car a) (car b)))))
+
+                ;; Merge overlapping or adjacent ranges.
+                (let ((merged-ranges '())
+                      (current-start nil)
+                      (current-end nil))
+                  (dolist (range line-ranges)
+                    (let ((start (car range))
+                          (end (cadr range)))
+                      (if (or (null current-start)
+                              ;; ; Not overlapping/adjacent.
+                              (> start (1+ current-end)))
+                          (progn
+                            (when current-start
+                              (push (list current-start current-end) merged-ranges))
+                            (setq
+                             current-start start
+                             current-end end))
+                        ;; Overlapping or adjacent - merge.
+                        (setq current-end (max current-end end)))))
+                  (when current-start
+                    (push (list current-start current-end) merged-ranges))
+                  (setq merged-ranges (reverse merged-ranges))
+
+                  ;; Output merged ranges with separators between non-adjacent ranges.
+                  (let ((need-separator nil))
+                    (dolist (range merged-ranges)
+                      (let ((start-line (car range))
+                            (end-line (cadr range)))
+                        ;; Add separator between non-adjacent ranges.
+                        (when need-separator
+                          (setq output (concat output "--\n")))
+                        (setq need-separator t)
+
+                        ;; Output lines in this range.
+                        (let ((i start-line))
+                          (while (<= i end-line)
+                            (let* ((line (nth (1- i) lines))
+                                   (is-match (gethash i match-lines-set)))
+                              (let* ((separator
+                                      (if is-match
+                                          ":"
+                                        "-"))
+                                     (line-format
+                                      (if show-line-numbers
+                                          (format "%s%s%d%s%s\n"
+                                                  file-path
+                                                  separator
+                                                  i
+                                                  separator
+                                                  line)
+                                        (format "%s%s%s\n" file-path separator line))))
+                                (setq output (concat output line-format))
+                                (setq i (1+ i)))))))))))
+
+            ;; Simple content mode without context.
+            (dolist (match matches)
+              (let* ((line-num (xref-file-location-line (xref-item-location match)))
+                     (summary (xref-item-summary match))
+                     (line-format
+                      (if show-line-numbers
+                          (format "%s:%d:%s\n" file-path line-num summary)
+                        (format "%s:%s\n" file-path summary))))
+                (setq output (concat output line-format))))))))
+
+    output))
+
+(cl-defun macher--tool-search-helper
+    (context
+     pattern
+     &key
+     path
+     file-regexp
+     mode
+     case-insensitive
+     lines-after
+     lines-before
+     show-line-numbers
+     head-limit)
+  "Search for PATTERN within the workspace using grep-like functionality.
+
+CONTEXT is a `macher-context' struct containing workspace information.
+
+PATTERN is the regular expression to search for (required).
+
+Keyword arguments:
+- PATH: directory or file to search, relative to workspace root.
+  Defaults to workspace root if not provided.
+
+- GLOB: file pattern relative to PATH to filter results (e.g., \"*.js\",
+  \"**/docker-compose*.yml\").
+
+- MODE: output format - \"files\" (default) shows file paths with match
+  counts, \"content\" shows grep-style matching lines with context.
+
+- CASE-INSENSITIVE: if non-nil, performs a case-insensitive
+  search (default: nil).
+
+- LINES-AFTER: number of lines to show after each match (content mode only).
+
+- LINES-BEFORE: number of lines to show before each match (content mode only).
+- SHOW-LINE-NUMBERS: if non-nil, includes line numbers in output (content
+  mode only).
+
+- HEAD-LIMIT: limits output to first N lines (like `head -N`).
+
+Returns formatted search results as a string. Considers workspace context
+including any pending changes, creations, or deletions.
+
+HEAD-LIMIT applies to the final formatted output and works exactly like
+piping the results through `head -N`."
+  (let ((search-mode (or mode "files")))
+    ;; Validate parameters.
+    (unless (and pattern (not (string-empty-p pattern)))
+      (error "Pattern is required and cannot be empty"))
+
+    (when (and head-limit (< head-limit 0))
+      (error "Head-limit cannot be negative"))
+
+    ;; Handle float inputs by rounding to integers, like the read tool does. Some LLMs seem to have
+    ;; trouble invoking tools with integer inputs.
+    (let* ((parsed-lines-after
+            (when lines-after
+              (round lines-after)))
+           (parsed-lines-before
+            (when lines-before
+              (round lines-before)))
+           (parsed-head-limit
+            (when head-limit
+              (round head-limit))))
+
+      ;; Get raw xref matches.
+      (let* ((matches-alist
+              (macher--search-get-xref-matches
+               context
+               pattern
+               :path path
+               :file-regexp file-regexp
+               :case-insensitive case-insensitive))
+             (output "No matches found."))
+
+        ;; Check if any matches were found.
+        (when matches-alist
+          ;; Format results based on mode.
+          (cond
+           ((string= search-mode "files")
+            (setq output (macher--search-format-files-mode matches-alist)))
+
+           ((string= search-mode "content")
+            (setq output
+                  (macher--search-format-content-mode
+                   context matches-alist parsed-lines-before parsed-lines-after show-line-numbers)))
+
+           (t
+            (error "Mode must be either 'files' or 'content'"))))
+
+        ;; Apply head-limit if specified.
+        (when parsed-head-limit
+          (let ((lines (split-string output "\n")))
+            (when (> (length lines) parsed-head-limit)
+              (setq output (string-join (seq-take lines parsed-head-limit) "\n")))))
+        output))))
+
+(defun macher--tool-search
+    (context
+     pattern
+     &optional
+     path
+     file-regexp
+     mode
+     case-insensitive
+     lines-after
+     lines-before
+     show-line-numbers
+     head-limit)
+  "Search for PATTERN within the workspace using grep-like functionality.
+
+CONTEXT is a `macher-context' struct containing workspace information.
+
+PATTERN is the regular expression to search for (required).
+
+PATH is the directory or file to search, relative to workspace root.
+Defaults to workspace root if not provided.
+
+FILE-REGEXP is a regular expression to filter files by path relative to
+search path.
+
+MODE specifies output format:
+- \"files\" (default) - Show file paths with match counts
+- \"content\" - Show grep-style matching lines with context
+
+CASE-INSENSITIVE, if non-nil, performs a case-insensitive search (default: nil).
+
+LINES-AFTER specifies number of lines to show after each match (content
+mode only).
+
+LINES-BEFORE specifies number of lines to show before each
+match (content mode only).
+
+SHOW-LINE-NUMBERS, if non-nil, includes line numbers in output (content
+mode only).
+
+HEAD-LIMIT limits output to first N lines (equivalent to piping through
+`head -N`).
+
+Returns formatted search results as a string. Considers workspace
+context including any pending changes, creations, or deletions."
+  (macher--tool-search-helper
+   context
+   pattern
+   :path path
+   :file-regexp file-regexp
+   :mode mode
+   :case-insensitive case-insensitive
+   :lines-after lines-after
+   :lines-before lines-before
+   :show-line-numbers show-line-numbers
+   :head-limit head-limit))
 
 (defun macher--read-tools (context make-tool-function)
   "Generate read-only tools for workspace operations with CONTEXT.
@@ -1188,46 +2353,153 @@ in the workspace.
 
 Tools are created using MAKE-TOOL-FUNCTION so they can be properly removed from
 the global gptel registry when the request completes."
-  (let* ((workspace (macher-context-workspace context))
-         (workspace-type (car workspace))
-         (workspace-id (cdr workspace))
-         (workspace-name (macher--workspace-name workspace))
-         (resolve-workspace-path (apply-partially #'macher--resolve-workspace-path workspace))
+  (list
+   (funcall
+    make-tool-function
+    :name "read_file_in_workspace"
+    :function (apply-partially #'macher--tool-read-file context)
+    :description
+    (concat
+     "Read file contents in the workspace.\n"
+     "\n"
+     "USAGE RULES:\n"
+     "1. NEVER re-read files that were already provided in the REQUEST CONTEXT\n"
+     "2. For files NOT in the REQUEST CONTEXT: try reading the ENTIRE file first "
+     "(no offset/limit) to understand its structure\n"
+     "\n"
+     "!!! CRITICAL: You MUST NOT use this tool to read files whose contents were already "
+     "provided to you in the REQUEST CONTEXT, except to resolve confusion or verify edits.\n"
+     "\n"
+     "Returns the file contents as a string.")
+    :confirm nil
+    :include nil
+    :args
+    `((:name "path" :type string :description "Path to the file, relative to workspace root")
+      (:name
+       "offset"
+       :type number
+       :optional t
+       :description
+       ,(concat
+         "Line number to start reading from (1-based). For negative values, starts at that many "
+         "lines before the end of the file. ONLY use for targeted re-reads - read entire file first!"))
+      (:name
+       "limit"
+       :type number
+       :optional t
+       :description
+       ,(concat
+         "Number of lines to read from the start position. For negative values, the actual "
+         "limit is computed as (total_lines + limit). For example, with a 100-line file: "
+         "limit=10 reads 10 lines, limit=-10 reads 90 lines (100 + (-10)). "
+         "ONLY use for targeted re-reads - read entire file first!"))
+      (:name
+       "show_line_numbers"
+       :type boolean
+       :optional t
+       :description
+       ,(concat
+         "Include line numbers in output (cat -n style: each line prefixed with right-aligned "
+         "line number and a tab character)"))))
 
-         ;; Shared helper to get or create implementation contents for a file.
-         (get-or-create-file-contents
-          (lambda (file-path)
-            "Get or create implementation contents for FILE-PATH, scoped to the current request.
-Returns a cons cell (orig-content . new-content) of strings for the file.
-Also updates the context's :contents alist."
-            (let ((full-path (funcall resolve-workspace-path file-path)))
-              (macher-context--contents-for-file full-path context)))))
-    (list
-     (funcall
-      make-tool-function
-      :name "read_file_in_workspace"
-      :function
-      `,(lambda (path)
-          "Read the contents of a file specified by PATH within the workspace."
-          (let* ((full-path (funcall resolve-workspace-path path))
-                 ;; Get implementation contents for this file.
-                 (contents (funcall get-or-create-file-contents path))
-                 (new-content (cdr contents)))
-            ;; Check if the file exists for reading.
-            (if (not new-content)
-                (error (format "File '%s' not found in workspace" path))
-              ;; Return the content directly.
-              new-content)))
-      :description
-      (concat
-       "Read file contents from the workspace. "
-       "Returns the current contents of a file. Use this ONLY when you need to see a file "
-       "that wasn't included in the initial context, or to verify changes after editing. "
-       "Do NOT use this to re-read files whose contents were already provided in the request context.")
-      :confirm nil
-      :include nil
-      :args
-      '((:name "path" :type string :description "Path to the file, relative to workspace root"))))))
+   (funcall make-tool-function
+            :name "list_directory_in_workspace"
+            :function (apply-partially #'macher--tool-list-directory context)
+            :description
+            (concat
+             "List directory contents in the workspace. "
+             "Shows files and directories with clear prefixes (file: or dir:). "
+             "Can optionally recurse into subdirectories and show file sizes. "
+             "Takes the current workspace state into account, including pending changes.\n\n"
+             "NOTE: The full workspace file listing is usually already provided in the "
+             "WORKSPACE CONTEXT. Only use this tool if you need specific directory "
+             "details or file sizes.")
+            :confirm nil
+            :include nil
+            :args
+            `((:name
+               "path"
+               :type string
+               :description "Path to the directory, relative to workspace root")
+              (:name
+               "recursive"
+               :type boolean
+               :optional t
+               :description "If true, recursively list subdirectories")
+              (:name
+               "sizes"
+               :type boolean
+               :optional t
+               :description "If true, include file sizes in the output")))
+
+   (funcall
+    make-tool-function
+    :name "search_in_workspace"
+    :function (apply-partially #'macher--tool-search context)
+    :description
+    (concat
+     "Search for patterns within the workspace using grep or something like it.\n"
+     "\n"
+     "Supports two output modes:\n"
+     "- 'files' (default): Shows file paths with match counts\n"
+     "- 'content': Shows matching lines with optional context\n"
+     "\n"
+     "!!! CRITICAL: You MUST NOT use this tool to search files whose contents were "
+     "already provided to you in the REQUEST CONTEXT. You already have their contents!")
+    :confirm nil
+    :include nil
+    :args
+    `((:name
+       "pattern"
+       :type string
+       :description "Regular expression pattern to search for (required)")
+      (:name
+       "path"
+       :type string
+       :optional t
+       :description "Directory or file to search, relative to workspace root (defaults to workspace root)")
+      (:name
+       "file_regexp"
+       :type string
+       :optional t
+       :description
+       ,(concat
+         "Filter files by regular expression matched against file path relative to search path. "
+         "Examples: '\\.py$' for Python files, 'src/.*\\.js$' for JS files in src/, "
+         "'test.*\\.py$' for test files"))
+      (:name
+       "mode"
+       :type string
+       :optional t
+       :description
+       ,(concat
+         "Output mode: 'files' (default, shows paths + counts) or "
+         "'content' (shows grep-style matching lines)"))
+      (:name
+       "case_insensitive"
+       :type boolean
+       :optional t
+       :description "If true, perform case-insensitive search (default: false)")
+      (:name
+       "lines_after"
+       :type number
+       :optional t
+       :description "Number of lines to show after each match (content mode only). Like `grep -A`.")
+      (:name
+       "lines_before"
+       :type number
+       :optional t
+       :description "Number of lines to show before each match (content mode only). Like `grep -B`.")
+      (:name
+       "show_line_numbers"
+       :type boolean
+       :optional t
+       :description "Include line numbers in output (content mode only). Like `grep -n`.")
+      (:name
+       "head_limit"
+       :type number
+       :optional t
+       :description "Limit output to first N lines (equivalent to piping through `head -N`)")))))
 
 (defun macher--edit-tools (context make-tool-function)
   "Generate file editing tools for workspace operations with CONTEXT.
@@ -1240,218 +2512,143 @@ Returns a list of tools that allow the LLM to edit files in the workspace.
 
 Tools are created using MAKE-TOOL-FUNCTION so they can be properly removed from
 the global gptel registry when the request completes."
-  (let* ((workspace (macher-context-workspace context))
-         (workspace-type (car workspace))
-         (workspace-id (cdr workspace))
-         (workspace-name (macher--workspace-name workspace))
-         (resolve-workspace-path (apply-partially #'macher--resolve-workspace-path workspace))
-         ;; Shared helper to get or create implementation contents for a file.
-         (get-or-create-file-contents
-          (lambda (file-path)
-            "Get or create implementation contents for FILE-PATH, scoped to the current request.
-Returns a cons cell (orig-content . new-content) of strings for the file.
-Also updates the context's :contents alist."
-            (let ((full-path (funcall resolve-workspace-path file-path)))
-              (macher-context--contents-for-file full-path context))))
-         ;; Wrapper function that sets the dirty-p flag before calling the actual tool function.
-         (wrap-edit-fn
-          (lambda (tool-fn)
-            "Wrap TOOL-FN to set the dirty-p flag before calling it."
-            (lambda (&rest args)
-              "Set dirty-p flag and call the wrapped tool function."
-              ;; Set the dirty flag to indicate changes are being made.
-              (setf (macher-context-dirty-p context) t)
-              ;; Call the original tool function.
-              (apply tool-fn args)))))
-    (list
-     (funcall
-      make-tool-function
-      :name "edit_file_in_workspace"
-      :function
-      (funcall
-       wrap-edit-fn
-       (lambda (path edits &optional dry-run)
-         "Edit file specified by PATH within the workspace.
-EDITS is a vector of edit operations, each containing :oldText and :newText.
-If DRY-RUN is non-nil, preview changes without applying them."
-         (let* ((full-path (funcall resolve-workspace-path path))
-                ;; Get implementation contents for this file.
-                (contents (funcall get-or-create-file-contents path))
-                (new-content (cdr contents))
-                ;; Handle :json-false inputs for dry-run parameter.
-                (dry-run (and dry-run (not (eq dry-run :json-false)))))
-           ;; Check if the file exists for editing.
-           (if (not new-content)
-               (error (format "File '%s' not found in workspace" path))
-             ;; Validate that edits is a vector, i.e. a JSON array. Ideally the argument should
-             ;; have been sent as an actual array, but some LLMs seem to have trouble with this,
-             ;; and instead send JSON strings which decode to an array. Allow both cases, as
-             ;; although the string case technically violates the tool signature, we can still
-             ;; handle it unambiguously.
-             (unless (vectorp edits)
-               (if (stringp edits)
-                   ;; Try to decode JSON string to vector.
-                   (condition-case nil
-                       (let ((decoded
-                              (json-parse-string edits :array-type 'vector :object-type 'plist)))
-                         (if (vectorp decoded)
-                             (setq edits decoded)
-                           (error
-                            "The 'edits' parameter must be an array, but the decoded JSON is not an array")))
-                     (error
-                      (error
-                       "The 'edits' parameter must be an array of objects, or a valid JSON string representing an array")))
-                 ;; Not a vector or string - invalid input.
-                 (error
-                  "The 'edits' parameter must be an array of objects, not %s" (type-of edits))))
-             ;; Apply edits sequentially.
-             (let ((applied-edits 0))
-               (cl-loop
-                for edit across edits do
-                (let ((old-text (plist-get edit :oldText))
-                      (new-text (plist-get edit :newText)))
+  (list
+   (funcall
+    make-tool-function
+    :name "edit_file_in_workspace"
+    :function (apply-partially #'macher--tool-edit-file context)
+    :description
+    (concat
+     "Make exact string replacements in a text file. "
+     "The old_text must match exactly including all whitespace, newlines, and indentation. "
+     "Do NOT include line numbers in old_text or new_text - use only the actual file content. "
+     "If replace_all is false and multiple matches exist, the operation fails - "
+     "provide more specific context in old_text to make the match unique. "
+     "Returns null on success.")
+    :confirm nil
+    :include nil
+    :args
+    `((:name "path" :type string :description "Path to the file, relative to workspace root")
+      (:name
+       "old_text"
+       :type string
+       :description
+       ,(concat
+         "Exact text to find and replace. Must match precisely including whitespace and "
+         "newlines. Do NOT include line numbers."))
+      (:name "new_text" :type string :description "Text to replace the old_text with")
+      (:name
+       "replace_all"
+       :type boolean
+       :optional t
+       :description "If true, replace all occurrences. If false (default), error if multiple matches exist")))
 
-                  (unless (and old-text new-text)
-                    (error "Each edit must contain oldText and newText properties"))
-                  (unless dry-run
-                    (setq new-content (macher--edit-string new-content old-text new-text))
-                    ;; Update the content in the context.
-                    (macher-context--set-new-content-for-file full-path new-content context))
-                  (setq applied-edits (1+ applied-edits))))
-
-               (unless dry-run
-                 nil))))))
-      :description
-      (concat
-       "Make line-based edits to a text file within the workspace. "
-       "Each edit replaces exact line sequences with new content. "
-       "Returns null on success, or an error message if any edit fails.")
-      :confirm nil
-      :include nil
-      :args
-      '((:name "path" :type string :description "Path to the file, relative to workspace root")
-        (:name
-         "edits"
-         :type array
-         :description "Array of edit operations. Each element must be an object with oldText and newText properties."
-         :items
+   (funcall
+    make-tool-function
+    :name "multi_edit_file_in_workspace"
+    :function (apply-partially #'macher--tool-multi-edit-file context)
+    :description
+    (concat
+     "Make multiple exact string replacements in a single file. "
+     "Edits are applied sequentially in array order to the same file. "
+     "Each edit requires exact whitespace matching. Do NOT include line numbers in old_text or new_text. "
+     "If any edit fails, no changes are made. Returns null on success.")
+    :confirm nil
+    :include nil
+    :args
+    `((:name "path" :type string :description "Path to the file, relative to workspace root")
+      (:name
+       "edits"
+       :type array
+       :description "Array of edit operations to apply in sequence"
+       :items
+       (:type
+        object
+        :properties
+        (:old_text
          (:type
-          object
-          :properties
-          (:oldText
-           (:type string :description "Text to search for - must match exactly")
-           :newText (:type string :description "Text to replace with"))
-          :required ["oldText" "newText"]))
-        (:name
-         "dryRun"
-         :type boolean
-         :optional t
-         :description "Preview changes without applying them (optional)")))
+          string
+          :description
+          ,(concat
+            "Exact text to find and replace. Must match precisely including whitespace "
+            "and newlines. Do NOT include line numbers."))
+         :new_text (:type string :description "Text to replace the old_text with")
+         :replace_all
+         (:type
+          boolean
+          :description "If true, replace all occurrences. If false (default), error if multiple matches exist"))
+        :required ["old_text" "new_text"]))))
 
-     (funcall make-tool-function
-              :name "write_file_in_workspace"
-              :function
-              (funcall
-               wrap-edit-fn
-               (lambda (path content)
-                 "Create a new file or completely overwrite an existing file with CONTENT.
-Use with caution as it will overwrite existing files without warning."
-                 (let* ((full-path (funcall resolve-workspace-path path)))
-                   ;; Set the new content in the context (this will create the entry if needed).
-                   (macher-context--set-new-content-for-file full-path content context)
-                   nil)))
-              :description
-              (concat
-               "Create a new file or completely overwrite an existing file in the workspace. "
-               "Use with caution as it will overwrite existing files without warning. "
-               "Handles text content with proper encoding.")
-              :confirm nil
-              :include nil
-              :args
-              '((:name
-                 "path"
-                 :type string
-                 :description "Path to the file, relative to workspace root")
-                (:name "content" :type string :description "Complete new content for the file")))
+   (funcall make-tool-function
+            :name "write_file_in_workspace"
+            :function (apply-partially #'macher--tool-write-file context)
+            :description
+            (concat
+             "Create a new file or completely overwrite an existing file. "
+             "WARNING: This replaces ALL existing content without warning. "
+             "Use edit_file_in_workspace for partial changes. "
+             "Returns null on success.")
+            :confirm nil
+            :include nil
+            :args
+            '((:name
+               "path"
+               :type string
+               :description "Path to the file, relative to workspace root")
+              (:name
+               "content"
+               :type string
+               :description "Complete new content that will replace the entire file")))
 
-     (funcall
-      make-tool-function
-      :name "move_file_in_workspace"
-      :function
-      (funcall wrap-edit-fn
-               (lambda (source destination)
-                 "Move or rename files within the workspace.
-SOURCE and DESTINATION are both relative to the workspace root.
-If the destination exists, the operation will fail."
-                 (let* ((source-full-path (funcall resolve-workspace-path source))
-                        (dest-full-path (funcall resolve-workspace-path destination))
-                        ;; Get implementation contents for the source file.
-                        (source-contents (funcall get-or-create-file-contents source))
-                        (source-new-content (cdr source-contents)))
-                   ;; Check if the source file exists.
-                   (unless source-new-content
-                     (error (format "Source file '%s' not found in workspace" source)))
-                   ;; Check if destination already exists.
-                   (let ((dest-contents (macher-context--contents-for-file dest-full-path context)))
-                     (when (cdr dest-contents)
-                       (error (format "Destination '%s' already exists" destination))))
-                   ;; Copy content from source to destination.
-                   (macher-context--set-new-content-for-file
-                    dest-full-path source-new-content context)
-                   ;; Mark source for deletion.
-                   (macher-context--set-new-content-for-file source-full-path nil context)
-                   nil)))
-      :description
-      (concat
-       "Move or rename files within the workspace."
-       "Can move files between directories and rename them in a single operation. "
-       "If the destination exists, the operation will fail. Works across different "
-       "directories and can be used for simple renaming within the same directory.")
-      :confirm nil
-      :include nil
-      :args
-      '((:name "source" :type string :description "Source path relative to workspace root")
-        (:name
-         "destination"
-         :type string
-         :description "Destination path relative to workspace root")))
+   (funcall make-tool-function
+            :name "move_file_in_workspace"
+            :function (apply-partially #'macher--tool-move-file context)
+            :description
+            (concat
+             "Move or rename files within the workspace. "
+             "Can move files between directories and rename them in a single operation. "
+             "Fails if the destination already exists. "
+             "Returns null on success.")
+            :confirm nil
+            :include nil
+            :args
+            '((:name
+               "source_path"
+               :type string
+               :description "Current path of the file to move, relative to workspace root")
+              (:name
+               "destination_path"
+               :type string
+               :description "New path for the file, relative to workspace root")))
 
-     (funcall make-tool-function
-              :name "delete_file_in_workspace"
-              :function
-              (funcall
-               wrap-edit-fn
-               (lambda (rel-path)
-                 "Delete a file specified by REL-PATH within the workspace.
-The file must exist and will be marked for deletion in the patch."
-                 (let* ((full-path (funcall resolve-workspace-path rel-path))
-                        ;; Get implementation contents for this file to properly record deletion.
-                        (contents (funcall get-or-create-file-contents rel-path))
-                        (editable-content (cdr contents)))
-                   ;; Check if the file exists before deleting.
-                   (if (not editable-content)
-                       (error (format "File '%s' not found in workspace" rel-path))
-                     ;; For deletion, set the new content to nil to indicate deletion.
-                     (macher-context--set-new-content-for-file full-path nil context)
-                     nil))))
-              :description
-              (concat
-               "Delete a file from the workspace. "
-               "Permanently removes the file. The file must exist in the workspace.")
-              :confirm nil
-              :include nil
-              :args
-              '((:name
-                 "path"
-                 :type string
-                 :description "Path to the file, relative to workspace root"))))))
+   (funcall make-tool-function
+            :name "delete_file_in_workspace"
+            :function (apply-partially #'macher--tool-delete-file context)
+            :description
+            (concat
+             "Delete a file from the workspace. "
+             "Fails if the file does not exist. "
+             "Returns null on success.")
+            :confirm nil
+            :include nil
+            :args
+            '((:name
+               "path"
+               :type string
+               :description "Path to the file to delete, relative to workspace root")))))
 
-(defun macher--edit-string (content old-string new-string)
+(defun macher--edit-string (content old-string new-string &optional replace-all)
   "In CONTENT string, replace OLD-STRING with NEW-STRING.
+
+If REPLACE-ALL is non-nil, replace all occurrences. Otherwise, error if
+multiple matches exist and replace only single occurrences.
 
 Return the new content string if the replacement was successful, or signal
 an error if it was not."
   (let ((case-fold-search nil))
+    ;; Error if old-string and new-string are identical
+    (when (string-equal old-string new-string)
+      (error "No changes to make: old_string and new_string are exactly the same"))
     ;; Handle empty old-string specially.
     (if (string-empty-p old-string)
         (if (string-empty-p content)
@@ -1462,40 +2659,41 @@ an error if it was not."
       ;; Normal case: old-string is not empty.
       (let* ((start 0)
              (matches 0)
-             (match-pos nil))
-        ;; Count matches.
+             (match-positions '()))
+        ;; Count matches and collect positions.
         (while (setq start (string-search old-string content start))
           (setq matches (1+ matches))
-          (when (= matches 1)
-            (setq match-pos start))
+          (push start match-positions)
           (setq start (+ start (length old-string))))
 
         (cond
          ((= matches 0)
-          (error "Could not find text to replace in content"))
-         ((> matches 1)
-          (error "Found %d matches for the text to replace in content" matches))
+          (error "String to replace not found in file"))
+         ((and (> matches 1) (not replace-all))
+          (error
+           (concat
+            "Found %d matches of the string to replace, but replace_all is false. "
+            "To replace all occurrences, set replace_all to true. To replace only one "
+            "occurrence, please provide more context to uniquely identify the instance")
+           matches))
          (t
-          ;; Exactly one match, perform the replacement.
-          (concat
-           (substring content 0 match-pos)
-           new-string
-           (substring content (+ match-pos (length old-string))))))))))
-
-(defun macher--write (fsm text)
-  "Write TEXT to the buffer for the action request managed by FSM."
-  (let* ((info (gptel-fsm-info fsm))
-         ;; Buffer and position to display a message.
-         (gptel-buffer (plist-get info :buffer))
-         (start-marker (plist-get info :position))
-         (tracking-marker (or (plist-get info :tracking-marker) start-marker)))
-    (with-current-buffer gptel-buffer
-      (goto-char tracking-marker)
-      (insert text)
-      ;; Update stored point for insertion. Adapted from `gptel-curl--stream-insert-response'.
-      (setq tracking-marker (set-marker (make-marker) (point)))
-      (set-marker-insertion-type tracking-marker t)
-      (plist-put info :tracking-marker tracking-marker))))
+          ;; Perform replacement(s)
+          (if replace-all
+              ;; Replace all occurrences (work backwards to preserve positions)
+              (let ((result content))
+                (dolist (pos (sort match-positions '>))
+                  (setq result
+                        (concat
+                         (substring result 0 pos)
+                         new-string
+                         (substring result (+ pos (length old-string))))))
+                result)
+            ;; Replace single occurrence
+            (let ((match-pos (car (reverse match-positions))))
+              (concat
+               (substring content 0 match-pos)
+               new-string
+               (substring content (+ match-pos (length old-string))))))))))))
 
 (defun macher--generate-patch-diff (context)
   "Generate a raw diff to populate the patch buffer.
@@ -1567,9 +2765,13 @@ CONTEXT is the 'macher-context' object. Returns the generated diff text."
 
 (defun macher-context--set-new-content-for-file (path content context)
   "Set the new content for PATH to CONTENT in the given CONTEXT.
-PATH should be an absolute file path within the project.
+
+PATH is any absolute file path. By default, macher will only call this
+for paths within the CONTEXT's workspace..
+
 CONTENT is the string content to use for the file, or nil if the file
 is being deleted.
+
 CONTEXT must be a `macher-context' struct.
 
 Updates the CONTEXT's :contents alist with the new content mapping."
@@ -2210,7 +3412,7 @@ which might also be included."
            transforms
            (when prompt-transform
              (list prompt-transform)))))
-    (plist-put keys :transforms updated-transforms)
+    (setq keys (plist-put (copy-sequence keys) :transforms updated-transforms))
 
     (when-let* (
                 ;; Send the request and get the state machine.

--- a/macher.el
+++ b/macher.el
@@ -1579,7 +1579,7 @@ Signals an error if the directory is not found in the workspace."
                  ;; Only include disk entries that are in the workspace files list.
                  (disk-entries
                   (if (file-directory-p current-path)
-                      (let ((all-disk-files (directory-files current-path nil "^[^.]")))
+                      (let ((all-disk-files (directory-files current-path)))
                         (cl-remove-if-not
                          (lambda (entry)
                            (let ((entry-full-path (expand-file-name entry current-path)))

--- a/macher.el
+++ b/macher.el
@@ -1582,18 +1582,20 @@ Signals an error if the directory is not found in the workspace."
                       (let ((all-disk-files (directory-files current-path)))
                         (cl-remove-if-not
                          (lambda (entry)
-                           (let ((entry-full-path (expand-file-name entry current-path)))
-                             ;; Include if it's in the workspace files list OR it's a directory.
-                             (or (cl-some
-                                  (lambda (workspace-file)
-                                    ;; Handle both absolute and relative paths in workspace-files.
-                                    (let ((normalized-workspace-file
-                                           (if (file-name-absolute-p workspace-file)
-                                               workspace-file
-                                             (expand-file-name workspace-file workspace-root))))
-                                      (string= entry-full-path normalized-workspace-file)))
-                                  workspace-files)
-                                 (file-directory-p entry-full-path))))
+                           ;; Exclude . and .. meta-directories to prevent infinite recursion.
+                           (unless (or (string= entry ".") (string= entry ".."))
+                             (let ((entry-full-path (expand-file-name entry current-path)))
+                               ;; Include if it's in the workspace files list OR it's a directory.
+                               (or (cl-some
+                                    (lambda (workspace-file)
+                                      ;; Handle both absolute and relative paths in workspace-files.
+                                      (let ((normalized-workspace-file
+                                             (if (file-name-absolute-p workspace-file)
+                                                 workspace-file
+                                               (expand-file-name workspace-file workspace-root))))
+                                        (string= entry-full-path normalized-workspace-file)))
+                                    workspace-files)
+                                   (file-directory-p entry-full-path)))))
                          all-disk-files))
                     '()))
                  ;; Add any newly created files from the context.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/git": "^10.0.1",
+        "@sourcemeta/jsonschema": "^10.0.0",
         "@tsconfig/node-lts": "^22.0.1",
         "semantic-release": "^24.2.5"
       }
@@ -742,6 +743,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@sourcemeta/jsonschema": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@sourcemeta/jsonschema/-/jsonschema-10.0.0.tgz",
+      "integrity": "sha512-NyRjy3JxFrcDU9zci4fTe4dhoUZu61UNONgxJ13hmhaUAYF51gYvVEoWpDtl1ckikdboMuAm/QVeelh/+B8hGQ==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "dev": true,
+      "license": "AGPL-3.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "jsonschema": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sourcemeta"
       }
     },
     "node_modules/@tsconfig/node-lts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Development dependencies for macher.el",
   "scripts": {
-    "test": "eask exec buttercup tests/",
+    "test": "eask exec buttercup --stale-file-error tests/",
     "postinstall": "eask install-deps --dev"
   },
   "devDependencies": {
@@ -12,6 +12,7 @@
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^10.0.1",
+    "@sourcemeta/jsonschema": "^10.0.0",
     "@tsconfig/node-lts": "^22.0.1",
     "semantic-release": "^24.2.5"
   }

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -206,9 +206,12 @@ Each element is a plist containing :model, :messages, :tools."
 
    (messages-of-type
     (lambda (requests type)
-      "Get a list of the actual content of messages filtered by type.
-Accepts a list of message plists, as returned by 'received-requests'.
-Returns a list of content strings."
+      "Get a list of the actual content of messages filtered by TYPE.
+
+Accepts a list of request plists, as returned by 'received-requests'.
+
+Returns a list of lists of content strings - that is, for each request,
+a list of the contents of messages whose role is TYPE."
       (seq-map
        (lambda (ms)
          (seq-map
@@ -680,7 +683,825 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
              (macher-context-contents macher-context)
              :to-equal `((,context-file . ("context content" . "context content")))))))))
 
-  (describe "tool lifecycle tests"
+  (describe "read_file_in_workspace"
+    (before-each
+      (funcall setup-project "read-tool" '(("test-file.txt" . "line1\nline2\nline3\nline4"))))
+
+    (it "returns full file content when called with no arguments"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function (:name "read_file_in_workspace" :arguments (:path "test-file.txt")))])
+                 "I read the file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+
+          ;; Check that received-requests contains a tool response with the file contents.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            (expect (cadr tool-messages) :to-equal '("line1\nline2\nline3\nline4"))))))
+
+    (it "supports the offset/limit parameters"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "read_file_in_workspace"
+                     :arguments (:path "test-file.txt" :offset 2 :limit 2)))])
+                 "I read specific lines from the file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with the limited file contents.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain lines 2-3 (offset 2, limit 2).
+            (expect (cadr tool-messages) :to-equal '("line2\nline3"))))))
+
+    (it "supports the numbered parameter for cat -n style output"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "read_file_in_workspace"
+                     :arguments (:path "test-file.txt" :show_line_numbers t)))])
+                 "I read the file with line numbers"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with numbered file contents.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain numbered lines (cat -n style).
+            (expect (cadr tool-messages) :to-equal '("1\tline1\n2\tline2\n3\tline3\n4\tline4"))))))
+
+    (it "returns error when file content exceeds max read length"
+      ;; Create a file with content that exceeds macher--max-read-length
+      (let* ((large-content (make-string (1+ macher--max-read-length) ?x))
+             (large-file-path (expand-file-name "large-file.txt" project-dir)))
+        (unwind-protect
+            (progn
+              ;; Create the large file in the existing project directory
+              (with-temp-file large-file-path
+                (insert large-content))
+              (funcall setup-backend
+                       '((:tool-calls
+                          [(:function
+                            (:name "read_file_in_workspace" :arguments (:path "large-file.txt")))])
+                         "I tried to read a large file"))
+              (let ((callback-called nil)
+                    (exit-code nil))
+                (with-temp-buffer
+                  (set-visited-file-name project-file)
+                  (macher-test--send
+                   'macher-ro "Test prompt"
+                   (lambda (cb-exit-code cb-fsm)
+                     (setq callback-called t)
+                     (setq exit-code cb-exit-code)))
+
+                  (let ((timeout 0))
+                    (while (and (not callback-called) (< timeout 100))
+                      (sleep-for 0.1)
+                      (setq timeout (1+ timeout))))
+
+                  (expect callback-called :to-be-truthy)
+
+                  ;; Check that received-requests contains a tool response with error message.
+                  (let* ((requests (funcall received-requests))
+                         (tool-messages (funcall messages-of-type requests "tool")))
+                    ;; We expect one element per received request.
+                    (expect (length tool-messages) :to-be 2)
+                    ;; No tool response included in the first request.
+                    (expect (car tool-messages) :to-be nil)
+                    ;; Second request should contain error message about file being too large.
+                    (let ((error-message (cadr tool-messages)))
+                      (expect (length error-message) :to-be 1)
+                      (expect "File content too large" :to-appear-once-in (car error-message))
+                      (expect
+                       "exceeds maximum read length"
+                       :to-appear-once-in (car error-message)))))))
+          ;; Clean up the large file
+          (when (file-exists-p large-file-path)
+            (delete-file large-file-path)))))
+
+    (it "handles float values for offset and limit parameters"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "read_file_in_workspace"
+                     :arguments (:path "test-file.txt" :offset 2.7 :limit 1.4)))])
+                 "I read specific lines with float parameters"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with the correctly rounded parameters.
+          ;; offset 2.7 should round to 3, limit 1.4 should round to 1
+          ;; So we should get line3 (1 line starting from offset 3)
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain line3 (offset 2.7 -> 3, limit 1.4 -> 1).
+            (expect (cadr tool-messages) :to-equal '("line3")))))))
+
+  (describe "edit_file_in_workspace"
+    (before-each
+      (funcall setup-project
+               "edit-tool"
+               '(("test-file.txt" . "hello world\nhello universe\nhello again"))))
+
+    (it "performs single edit without replace_all"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "edit_file_in_workspace"
+                     :arguments
+                     (:path "test-file.txt" :old_text "hello universe" :new_text "hi universe")))])
+                 "I edited the file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with null (success).
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain null (success).
+            (expect (cadr tool-messages) :to-equal '("nil"))))))
+
+    (it "performs replace_all edit"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "edit_file_in_workspace"
+                     :arguments
+                     (:path "test-file.txt" :old_text "hello" :new_text "hi" :replace_all t)))])
+                 "I edited all occurrences in the file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with null (success).
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain null (success).
+            (expect (cadr tool-messages) :to-equal '("nil")))))))
+
+  (describe "multi_edit_file_in_workspace"
+    (before-each
+      (funcall setup-project
+               "multi-edit-tool"
+               '(("test-file.txt" . "hello world\nhello universe\ngoodbye world"))))
+
+    (it "performs multiple edits without replace_all"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "multi_edit_file_in_workspace"
+                     :arguments
+                     (:path
+                      "test-file.txt"
+                      :edits
+                      [(:old_text "hello world" :new_text "hi world")
+                       (:old_text "goodbye world" :new_text "farewell world")])))])
+                 "I made multiple edits to the file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with null (success).
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain null (success).
+            (expect (cadr tool-messages) :to-equal '("nil"))))))
+
+    (it "performs multiple edits with replace_all"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "multi_edit_file_in_workspace"
+                     :arguments
+                     (:path
+                      "test-file.txt"
+                      :edits
+                      [(:old_text "hello" :new_text "hi" :replace_all t)
+                       (:old_text "goodbye world" :new_text "farewell planet")])))])
+                 "I made multiple edits with replace_all"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with null (success).
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain null (success).
+            (expect (cadr tool-messages) :to-equal '("nil")))))))
+
+  (describe "delete_file_in_workspace"
+    (before-each
+      (funcall setup-project
+               "delete-tool"
+               '(("test-file.txt" . "This file will be deleted")
+                 ("keep-file.txt" . "This file should remain"))))
+
+    (it "deletes an existing file successfully"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name "delete_file_in_workspace" :arguments (:path "test-file.txt")))])
+                 "I deleted the file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with null (success).
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain null (success).
+            (expect (cadr tool-messages) :to-equal '("nil"))))))
+
+    (it "returns error when trying to delete non-existent file"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name "delete_file_in_workspace" :arguments (:path "non-existent-file.txt")))])
+                 "I tried to delete a file that doesn't exist"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with error message.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain error message.
+            (let ((error-message (cadr tool-messages)))
+              (expect (length error-message) :to-be 1)
+              (expect
+               ;; When a tool raises an error, the quotes in the formatted string that gets returned
+               ;; apper to get changed, e.g. ' -> `.
+               "File .non-existent-file\.txt. not found in workspace"
+               :to-appear-once-in (car error-message)))))))
+
+    (it "generates proper diff when file is deleted"
+      (funcall setup-backend
+               `((:tool-calls
+                  [(:function
+                    (:name "delete_file_in_workspace" :arguments (:path "test-file.txt")))])
+                 "Finished deleting file"))
+      (let* ((callback-called nil)
+             (exit-code nil)
+             (fsm nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt to delete a file."
+           (macher-test--make-once-only-callback
+            (lambda (cb-exit-code cb-fsm)
+              (setq callback-called t)
+              (setq exit-code cb-exit-code)
+              (setq fsm cb-fsm))))
+
+          ;; Wait for the async response.
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+          (expect exit-code :to-be nil)
+          (expect (gptel-fsm-state fsm) :to-be 'DONE)
+
+          (with-current-buffer (macher-patch-buffer)
+            (let ((patch (buffer-string)))
+              ;; Should contain diff header for file deletion
+              (expect
+               (regexp-quote
+                (concat
+                 "diff --git a/test-file.txt b/test-file.txt\n"
+                 "--- a/test-file.txt\n"
+                 "+++ /dev/null\n"
+                 "@@ -1 +0,0 @@\n"
+                 "-This file will be deleted"))
+               :to-appear-once-in patch)
+
+              ;; Should contain the prompt for reference
+              (expect "Test prompt to delete a file" :to-appear-once-in patch)))))))
+
+  (describe "write_file_in_workspace"
+    (before-each
+      (funcall setup-project "write-tool" '(("existing-file.txt" . "existing content"))))
+
+    (it "creates a new file successfully"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "write_file_in_workspace"
+                     :arguments (:path "new-file.txt" :content "new file content")))])
+                 "I created a new file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with null (success).
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain null (success).
+            (expect (cadr tool-messages) :to-equal '("nil"))))))
+
+    (it "overwrites existing file successfully"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "write_file_in_workspace"
+                     :arguments (:path "existing-file.txt" :content "overwritten content")))])
+                 "I overwrote the existing file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with null (success).
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain null (success).
+            (expect (cadr tool-messages) :to-equal '("nil"))))))
+
+    (it "generates proper diff when file is created"
+      (funcall setup-backend
+               `((:tool-calls
+                  [(:function
+                    (:name
+                     "write_file_in_workspace"
+                     :arguments (:path "created-file.txt" :content "created content")))])
+                 "Finished creating file"))
+      (let* ((callback-called nil)
+             (exit-code nil)
+             (fsm nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt to create a file."
+           (macher-test--make-once-only-callback
+            (lambda (cb-exit-code cb-fsm)
+              (setq callback-called t)
+              (setq exit-code cb-exit-code)
+              (setq fsm cb-fsm))))
+
+          ;; Wait for the async response.
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+          (expect exit-code :to-be nil)
+          (expect (gptel-fsm-state fsm) :to-be 'DONE)
+
+          (with-current-buffer (macher-patch-buffer)
+            (let ((patch (buffer-string)))
+              ;; Should contain diff header for file creation
+              (expect
+               (regexp-quote
+                (concat
+                 "diff --git a/created-file.txt b/created-file.txt\n"
+                 "--- /dev/null\n"
+                 "+++ b/created-file.txt\n"
+                 "@@ -0,0 +1 @@\n"
+                 "+created content"))
+               :to-appear-once-in patch)
+
+              ;; Should contain the prompt for reference
+              (expect "Test prompt to create a file" :to-appear-once-in patch)))))))
+
+  (describe "move_file_in_workspace"
+    (before-each
+      (funcall setup-project
+               "move-tool"
+               '(("source-file.txt" . "content to move") ("other-file.txt" . "other content"))))
+
+    (it "moves a file successfully"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "move_file_in_workspace"
+                     :arguments
+                     (:source_path "source-file.txt" :destination_path "destination-file.txt")))])
+                 "I moved the file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with null (success).
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain null (success).
+            (expect (cadr tool-messages) :to-equal '("nil"))))))
+
+    (it "renames a file in the same directory successfully"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "move_file_in_workspace"
+                     :arguments
+                     (:source_path "source-file.txt" :destination_path "renamed-file.txt")))])
+                 "I renamed the file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with null (success).
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain null (success).
+            (expect (cadr tool-messages) :to-equal '("nil"))))))
+
+    (it "returns error when source file doesn't exist"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "move_file_in_workspace"
+                     :arguments
+                     (:source_path "non-existent.txt" :destination_path "destination.txt")))])
+                 "I tried to move a non-existent file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with error message.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain error message.
+            (let ((error-message (cadr tool-messages)))
+              (expect (length error-message) :to-be 1)
+              (expect
+               "File .non-existent\.txt. not found in workspace"
+               :to-appear-once-in (car error-message)))))))
+
+    (it "returns error when destination already exists"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "move_file_in_workspace"
+                     :arguments
+                     (:source_path "source-file.txt" :destination_path "other-file.txt")))])
+                 "I tried to move to an existing file"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with error message.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            ;; We expect one element per received request.
+            (expect (length tool-messages) :to-be 2)
+            ;; No tool response included in the first request.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request should contain error message.
+            (let ((error-message (cadr tool-messages)))
+              (expect (length error-message) :to-be 1)
+              (expect
+               "Destination .other-file\.txt. already exists"
+               :to-appear-once-in (car error-message)))))))
+
+    (it "generates proper diff when file is moved"
+      (funcall setup-backend
+               `((:tool-calls
+                  [(:function
+                    (:name
+                     "move_file_in_workspace"
+                     :arguments
+                     (:source_path "source-file.txt" :destination_path "moved-file.txt")))])
+                 "Finished moving file"))
+      (let* ((callback-called nil)
+             (exit-code nil)
+             (fsm nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt to move a file."
+           (macher-test--make-once-only-callback
+            (lambda (cb-exit-code cb-fsm)
+              (setq callback-called t)
+              (setq exit-code cb-exit-code)
+              (setq fsm cb-fsm))))
+
+          ;; Wait for the async response.
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+          (expect exit-code :to-be nil)
+          (expect (gptel-fsm-state fsm) :to-be 'DONE)
+
+          (with-current-buffer (macher-patch-buffer)
+            (let ((patch (buffer-string)))
+              ;; Should contain diff header for file creation (destination)
+              (expect
+               (regexp-quote
+                (concat
+                 "diff --git a/moved-file.txt b/moved-file.txt\n"
+                 "--- /dev/null\n"
+                 "+++ b/moved-file.txt\n"
+                 "@@ -0,0 +1 @@\n"
+                 "+content to move"))
+               :to-appear-once-in patch)
+
+              ;; Should contain diff header for file deletion (source)
+              (expect
+               (regexp-quote
+                (concat
+                 "diff --git a/source-file.txt b/source-file.txt\n"
+                 "--- a/source-file.txt\n"
+                 "+++ /dev/null\n"
+                 "@@ -1 +0,0 @@\n"
+                 "-content to move"))
+               :to-appear-once-in patch)
+
+              ;; Should contain the prompt for reference
+              (expect "Test prompt to move a file" :to-appear-once-in patch)))))))
+
+  (describe "tool specs"
     (it "includes tools in request for macher presets"
       (funcall setup-backend '("Test response"))
       (funcall setup-project "tools")
@@ -726,7 +1547,79 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                    :to-be-truthy))))
           ;; Clean up.
           (when (file-exists-p temp-file)
-            (delete-file temp-file))))))
+            (delete-file temp-file)))))
+
+    ;; Anthropic expects an input_schema parameter, which contains a valid JSON schema describing
+    ;; the tool arguments. This parameter gets added in the custom `gptel--parse-tools'
+    ;; implementation for Anthropic backends.
+    ;;
+    ;; Other backends are a bit more flexible with non-conforming tool schemas, so there are some
+    ;; potential schema errors that wouldn't be picked up by other tests - for example, a
+    ;; ':required' array being present somewhere that it shouldn't be, maybe one level too deep.
+    ;; This test checks that we're able to generate a strictly correct JSON schema from our tool
+    ;; definitions, in particular for the Anthropic API, though this also validates that we aren't
+    ;; sending any unintentionally weird schemas to other backends.
+    (it "generates a valid input schema for anthropic backends"
+      (require 'gptel-anthropic)
+      (let* ( ;; Avoid modifications to the global registry.
+             (gptel--known-backends nil)
+             (anthropic (gptel-make-anthropic "Test Anthropic")))
+        (macher--with-preset
+         'macher
+         (lambda ()
+           (let ((parsed-tools (gptel--parse-tools anthropic gptel-tools)))
+             (expect (vectorp parsed-tools) :to-be-truthy)
+             (let ((tools-list (append parsed-tools nil)))
+               ;; The exact number of tools might change; just sanity check that there are at least
+               ;; several of them.
+               (expect (> (length tools-list) 4) :to-be-truthy)
+               (dolist (tool tools-list)
+                 (let ((input-schema (plist-get tool :input_schema)))
+                   (expect input-schema :to-be-truthy)
+                   (let*
+                       (
+                        ;; A schema that just inherits from the JSON schema "meta-schema" (i.e. the
+                        ;; schema for JSON schemas) expected by Anthropic.
+                        (meta-schema
+                         (concat
+                          "{\"$schema\": \"https://json-schema.org/draft/2020-12/schema\","
+                          "\"$ref\": \"https://json-schema.org/draft/2020-12/schema\"}"))
+                        (input-schema-json (gptel--json-encode input-schema))
+                        (meta-schema-file (make-temp-file "meta-schema" nil ".json"))
+                        (input-schema-file (make-temp-file "input-schema" nil ".json")))
+                     (unwind-protect
+                         (progn
+                           ;; Write the meta-schema to a temporary file.
+                           (with-temp-file meta-schema-file
+                             (insert meta-schema))
+                           ;; Write the input schema to a temporary file.
+                           (with-temp-file input-schema-file
+                             (insert input-schema-json))
+                           (with-temp-buffer
+                             ;; Validate using https://github.com/sourcemeta/jsonschema.
+                             (let ((exit-code
+                                    (call-process "npx"
+                                                  nil
+                                                  (current-buffer)
+                                                  nil
+                                                  "jsonschema"
+                                                  "validate"
+                                                  meta-schema-file
+                                                  input-schema-file)))
+
+                               ;; Add some additional context as warning output.
+                               (unless (eq exit-code 0)
+                                 (display-warning
+                                  'buttercup
+                                  (format "Error in schema for tool %s:\n\n%s"
+                                          (plist-get tool :name)
+                                          (buffer-string))))
+                               (expect exit-code :to-be 0))))
+                       ;; Clean up temporary files
+                       (when (file-exists-p meta-schema-file)
+                         (delete-file meta-schema-file))
+                       (when (file-exists-p input-schema-file)
+                         (delete-file input-schema-file)))))))))))))
 
   (describe "context string generation"
 
@@ -780,18 +1673,27 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
               (let ((system-content
                      (mapconcat (lambda (msg) (plist-get msg :content)) system-messages " ")))
                 ;; Check for workspace description.
-                (expect "WORKSPACE CONTEXT" :to-appear-once-in system-content)
-                ;; Check that all files are present but not marked with [*] since nothing is in context.
-                (expect "    README.md" :to-appear-once-in system-content)
-                (expect "    src/main.el" :to-appear-once-in system-content)
-                (expect "    src/util.el" :to-appear-once-in system-content)
-                (expect "    test/test-main.el" :to-appear-once-in system-content)
-                ;; Check that no files are marked with [*] since nothing is in context.
-                (expect system-content :not :to-match "\\[\\*\\]")
+                (expect "^WORKSPACE CONTEXT" :to-appear-once-in system-content)
+                ;; Check that all files are listed as available for editing since nothing is in context.
+                (expect "Files available for editing:" :to-appear-once-in system-content)
+                ;; Check that files appear in the correct structural relationship to the header.
+                (expect
+                 system-content
+                 :to-match "Files available for editing:\n\\(    [^\n]*\n\\)*    README\\.md")
+                (expect
+                 system-content
+                 :to-match "Files available for editing:\n\\(    [^\n]*\n\\)*    src/main\\.el")
+                (expect
+                 system-content
+                 :to-match "Files available for editing:\n\\(    [^\n]*\n\\)*    src/util\\.el")
+                (expect
+                 system-content
+                 :to-match "Files available for editing:\n\\(    [^\n]*\n\\)*    test/test-main\\.el")
+                ;; Should not have an "already provided" section since nothing is in context.
+                (expect system-content :not :to-match "Files already provided above")
                 ;; Check that it mentions the project name in the description.
                 (expect
-                 (format "In-memory editing environment for '%s'"
-                         (file-name-nondirectory project-dir))
+                 (format "which is named `%s`" (file-name-nondirectory project-dir))
                  :to-appear-once-in system-content)))))))
 
     (it "includes workspace info when both files and buffers are in context"
@@ -855,19 +1757,30 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                     (let ((system-content
                            (mapconcat (lambda (msg) (plist-get msg :content)) system-messages " ")))
                       ;; Check for workspace description.
-                      (expect "WORKSPACE CONTEXT" :to-appear-once-in system-content)
-                      ;; Check that the context file is marked with [*].
-                      (expect "\\[\\*\\] src/context.el" :to-appear-once-in system-content)
-                      ;; Check that other files are not marked, including the one that was loaded as a buffer.
-                      (expect "    src/buffer.el" :to-appear-once-in system-content)
-                      (expect "    docs/README.md" :to-appear-once-in system-content)
-                      (expect "    src/main.el" :to-appear-once-in system-content)
+                      (expect "^WORKSPACE CONTEXT" :to-appear-once-in system-content)
+                      ;; Check that files in context are in the "already provided" section.
+                      (expect "Files already provided above" :to-appear-once-in system-content)
+                      (expect
+                       system-content
+                       :to-match "Files already provided above.*\n    src/context\\.el")
+                      ;; Check that other files are in the "available for editing" section with proper structure.
+                      (expect
+                       "Other files available for editing:"
+                       :to-appear-once-in system-content)
+                      (expect
+                       system-content
+                       :to-match "Other files available for editing:\n\\(    [^\n]*\n\\)*    src/buffer\\.el")
+                      (expect
+                       system-content
+                       :to-match "Other files available for editing:\n\\(    [^\n]*\n\\)*    docs/README\\.md")
+                      (expect
+                       system-content
+                       :to-match "Other files available for editing:\n\\(    [^\n]*\n\\)*    src/main\\.el")
                       ;; Check that buffer content appears in context (since buffer was added).
                       (expect "Buffer file content" :to-appear-once-in system-content)
                       ;; Check that it mentions the project name in the description.
                       (expect
-                       (format "In-memory editing environment for '%s'"
-                               (file-name-nondirectory project-dir))
+                       (format "which is named `%s`" (file-name-nondirectory project-dir))
                        :to-appear-once-in system-content))))))
           ;; Clean up the buffer.
           (when (buffer-live-p buffer-buffer)
@@ -927,17 +1840,24 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                 (let ((system-content
                        (mapconcat (lambda (msg) (plist-get msg :content)) system-messages " ")))
                   ;; Check for workspace description.
-                  (expect "WORKSPACE CONTEXT" :to-appear-once-in system-content)
-                  ;; Check that all files are present with proper context markers.
-                  (expect "    README.md" :to-appear-once-in system-content)
-                  (expect "\\[\\*\\] src/main.el" :to-appear-once-in system-content)
-                  (expect "    test/test-file.el" :to-appear-once-in system-content)
+                  (expect "^WORKSPACE CONTEXT" :to-appear-once-in system-content)
+                  ;; Check that files are properly separated between context and available.
+                  (expect "Files already provided above" :to-appear-once-in system-content)
+                  (expect
+                   system-content
+                   :to-match "Files already provided above.*\n    src/main\\.el")
+                  (expect "Other files available for editing:" :to-appear-once-in system-content)
+                  (expect
+                   system-content
+                   :to-match "Other files available for editing:\n\\(    [^\n]*\n\\)*    README\\.md")
+                  (expect
+                   system-content
+                   :to-match "Other files available for editing:\n\\(    [^\n]*\n\\)*    test/test-file\\.el")
                   ;; Check that file content appears in context.
                   (expect "Main file content" :to-appear-once-in system-content)
                   ;; Check that it mentions the project name in the description.
                   (expect
-                   (format "In-memory editing environment for '%s'"
-                           (file-name-nondirectory project-dir))
+                   (format "which is named `%s`" (file-name-nondirectory project-dir))
                    :to-appear-once-in system-content))))))))
 
     (it "includes workspace info when only buffers are in context"
@@ -997,17 +1917,22 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                     (let ((system-content
                            (mapconcat (lambda (msg) (plist-get msg :content)) system-messages " ")))
                       ;; Check for workspace description.
-                      (expect "WORKSPACE CONTEXT" :to-appear-once-in system-content)
-                      ;; Check that all files are present but not marked as context (including other.el, which
-                      ;; is present in context but only as a buffer).
-                      (expect "    first.el" :to-appear-once-in system-content)
-                      (expect "    src/second.el" :to-appear-once-in system-content)
-                      (expect "    src/third.el" :to-appear-once-in system-content)
+                      (expect "^WORKSPACE CONTEXT" :to-appear-once-in system-content)
+                      ;; Check that all files are listed (buffer context doesn't affect file listing).
+                      (expect "Files available for editing:" :to-appear-once-in system-content)
+                      (expect
+                       system-content
+                       :to-match "Files available for editing:\n\\(    [^\n]*\n\\)*    first\\.el")
+                      (expect
+                       system-content
+                       :to-match "Files available for editing:\n\\(    [^\n]*\n\\)*    src/second\\.el")
+                      (expect
+                       system-content
+                       :to-match "Files available for editing:\n\\(    [^\n]*\n\\)*    src/third\\.el")
                       (expect "second content" :to-appear-once-in system-content)
                       ;; Check that it mentions the project name in the description.
                       (expect
-                       (format "In-memory editing environment for '%s'"
-                               (file-name-nondirectory project-dir))
+                       (format "which is named `%s`" (file-name-nondirectory project-dir))
                        :to-appear-once-in system-content))))))
           (when context-buffer
             (kill-buffer context-buffer))))))
@@ -1175,8 +2100,506 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                ;; the prompt and the trailing prompt prefix.
                :to-equal (funcall action-buffer-content "Test abort request" "" 'discuss))))))))
 
-  (describe "patch generation tests"
+  (describe "search_in_workspace"
+    (before-each
+      (funcall setup-project
+               "search-tool"
+               '(("src/main.js"
+                  .
+                  "console.log('hello world');\nfunction test() {\n  return 'hello universe';\n}")
+                 ("src/utils.js" . "export function hello() {\n  return 'hello javascript';\n}")
+                 ("README.md" . "# Hello Project\n\nThis is a test project with hello examples.")
+                 ("tests/test.js" . "test('hello test', () => {\n  expect(true).toBe(true);\n});")
+                 ("config.yaml" . "name: hello-app\nversion: 1.0.0"))))
 
+    (after-each
+      ;; Clean up any file buffers that might have been created during search operations. The search
+      ;; tool may open files to search through them, and we need to clean those up.
+      (dolist (buffer (buffer-list))
+        (when (buffer-file-name buffer)
+          (let ((file-path (buffer-file-name buffer)))
+            ;; Only kill buffers for files within our test project directory.
+            (when (and project-dir (string-prefix-p project-dir file-path))
+              (kill-buffer buffer))))))
+
+    (it "searches with files mode (default)"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function (:name "search_in_workspace" :arguments (:pattern "hello")))])
+                 "I found hello in multiple files"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with search results.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((search-result (cadr tool-messages)))
+              (expect (length search-result) :to-be 1)
+              (expect (car search-result) :to-match "README.md (1 match)")
+              (expect (car search-result) :to-match "config.yaml (1 match)")
+              (expect (car search-result) :to-match "src/main.js (2 matches)")
+              (expect (car search-result) :to-match "src/utils.js (2 matches)")
+              (expect (car search-result) :to-match "tests/test.js (1 match)")
+              (expect (car search-result) :to-match "Total: 7 matches in 5 files"))))))
+
+    (it "searches with content mode and context lines"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "search_in_workspace"
+                     :arguments
+                     (:pattern
+                      "hello"
+                      :mode "content"
+                      :lines_before 1
+                      :lines_after 1
+                      :show_line_numbers t)))])
+                 "I found hello with context"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with content results.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((search-result (cadr tool-messages)))
+              (expect (length search-result) :to-be 1)
+              (expect
+               (car search-result)
+               :to-match "README.md:3:This is a test project with hello examples.")
+              (expect (car search-result) :to-match "config.yaml:1:name: hello-app")
+              (expect (car search-result) :to-match "src/main.js:1:console.log('hello world');")
+              (expect (car search-result) :to-match "src/main.js:3:  return 'hello universe';")
+              (expect (car search-result) :to-match "src/utils.js:1:export function hello() {")
+              (expect (car search-result) :to-match "src/utils.js:2:  return 'hello javascript';")
+              (expect
+               (car search-result)
+               :to-match "tests/test.js:1:test('hello test', () => {"))))))
+
+    (it "searches with regexp file filtering"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "search_in_workspace"
+                     :arguments (:pattern "hello" :file_regexp "\\.js$")))])
+                 "I found hello in JavaScript files"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that only JS files are included in results.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((search-result (cadr tool-messages)))
+              (expect (length search-result) :to-be 1)
+              ;; Should only match .js files with file_regexp "\\.js$".
+              (expect (car search-result) :to-match "src/main.js (2 matches)")
+              (expect (car search-result) :to-match "src/utils.js (2 matches)")
+              (expect (car search-result) :to-match "tests/test.js (1 match)")
+              ;; These should NOT match with .js file_regexp.
+              (expect (car search-result) :not :to-match "README.md")
+              (expect (car search-result) :not :to-match "config.yaml")
+              (expect (car search-result) :to-match "Total: 5 matches in 3 files"))))))
+
+    (it "searches case-insensitively"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "search_in_workspace"
+                     :arguments (:pattern "HElLO" :case_insensitive t)))])
+                 "I found HELLO case-insensitively"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that case-insensitive search found matches.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((search-result (cadr tool-messages)))
+              (expect (length search-result) :to-be 1)
+              ;; Should find matches despite case difference.
+              (expect (car search-result) :to-match "README.md (2 matches)")
+              (expect (car search-result) :to-match "config.yaml (1 match)")
+              (expect (car search-result) :to-match "src/main.js (2 matches)")
+              (expect (car search-result) :to-match "src/utils.js (2 matches)")
+              (expect (car search-result) :to-match "tests/test.js (1 match)")
+              (expect (car search-result) :to-match "Total: 8 matches in 5 files"))))))
+
+    (it "limits results with head_limit parameter"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name "search_in_workspace" :arguments (:pattern "hello" :head_limit 2)))])
+                 "I found hello with limited results"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that results are limited to 2 files.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((search-result (cadr tool-messages)))
+              (expect (length search-result) :to-be 1)
+              ;; Should have results limited to 2 lines (head_limit=2), just like `head -2`.
+              (let ((lines (split-string (car search-result) "\n")))
+                (expect (length lines) :to-be 2)))))))
+
+    (it "searches in specific directory path"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name "search_in_workspace" :arguments (:pattern "hello" :path "src")))])
+                 "I found hello in src directory"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that only src directory files are included
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((search-result (cadr tool-messages)))
+              (expect (length search-result) :to-be 1)
+              (expect (car search-result) :to-match "src/main.js (2 matches)")
+              (expect (car search-result) :to-match "src/utils.js (2 matches)")
+              (expect (car search-result) :not :to-match "README.md")
+              (expect (car search-result) :not :to-match "config.yaml")
+              (expect (car search-result) :not :to-match "tests/test.js")
+              (expect (car search-result) :to-match "Total: 4 matches in 2 files"))))))
+
+    (it "handles workspace context with modified files"
+      ;; Edit a file and then search to verify the changes show up.
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "edit_file_in_workspace"
+                     :arguments
+                     (:path
+                      "src/main.js"
+                      :old_text "'hello universe'"
+                      :new_text "'hello UNIQUEWORD'")))
+                   (:function
+                    (:name "search_in_workspace" :arguments (:pattern "hello" :mode "content")))])
+                 "I modified a file and searched for hello"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that search reflects the modified workspace context.
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            ;; First request is the prompt, and has no tool result content.
+            (expect (car tool-messages) :to-be nil)
+            ;; Second request is the response to the tool calls.
+            (let ((search-result (cadr tool-messages)))
+              ;; Both the edit call and the search call were included in a single response.
+              (expect (length search-result) :to-be 2)
+              (expect (car search-result) :to-equal "nil")
+              (let ((search-content (cadr search-result))
+                    (expected-content
+                     (concat
+                      "src/main.js:console.log('hello world');\n"
+                      "src/main.js:  return 'hello UNIQUEWORD';\n"
+                      "README.md:This is a test project with hello examples.\n"
+                      "config.yaml:name: hello-app\n"
+                      "src/utils.js:export function hello() {\n"
+                      "src/utils.js:  return 'hello javascript';\n"
+                      "tests/test.js:test('hello test', () => {\n")))
+                ;; This proves the edit worked: UNIQUEWORD present, universe absent
+                (expect search-content :to-equal expected-content))))))))
+
+  (describe "list_directory_in_workspace"
+    (before-each
+      (funcall setup-project
+               "list-dir-tool"
+               '(("file1.txt" . "content1")
+                 ("file2.el" . "content2")
+                 ("subdir/file3.md" . "content3")
+                 ("subdir/nested/file4.txt" . "content4"))))
+
+    (it "lists directory contents without recursion or sizes"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function (:name "list_directory_in_workspace" :arguments (:path ".")))])
+                 "I listed the directory"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with directory listing
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((listing (cadr tool-messages)))
+              (expect (length listing) :to-be 1)
+              (expect (car listing) :to-match "file: file1.txt")
+              (expect (car listing) :to-match "file: file2.el")
+              (expect (car listing) :to-match "dir: subdir")
+              (expect (car listing) :not :to-match "file3.md") ; Not recursive
+              (expect (car listing) :not :to-match "B)")))))) ; No sizes
+
+    (it "lists directory contents with sizes"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name "list_directory_in_workspace" :arguments (:path "." :sizes t)))])
+                 "I listed the directory with sizes"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with sizes
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((listing (cadr tool-messages)))
+              (expect (length listing) :to-be 1)
+              (expect (car listing) :to-match "file: file1.txt (8 B)")
+              (expect (car listing) :to-match "file: file2.el (8 B)")
+              (expect (car listing) :to-match "dir: subdir$")) ; No size for directory
+            ))))
+
+    (it "lists directory contents recursively"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name "list_directory_in_workspace" :arguments (:path "." :recursive t)))])
+                 "I listed the directory recursively"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with recursive listing
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((listing (cadr tool-messages)))
+              (expect (length listing) :to-be 1)
+              (expect (car listing) :to-match "file: file1.txt")
+              (expect (car listing) :to-match "dir: subdir")
+              (expect (car listing) :to-match "  file: subdir/file3.md")
+              (expect (car listing) :to-match "  dir: subdir/nested")
+              (expect (car listing) :to-match "    file: subdir/nested/file4.txt"))))))
+
+    (it "lists subdirectory contents"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function (:name "list_directory_in_workspace" :arguments (:path "subdir")))])
+                 "I listed the subdirectory"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with subdirectory listing
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((listing (cadr tool-messages)))
+              (expect (length listing) :to-be 1)
+              (expect (car listing) :to-match "file: file3.md")
+              (expect (car listing) :to-match "dir: nested")
+              (expect (car listing) :not :to-match "file1.txt")
+              (expect (car listing) :not :to-match "file2.el"))))))
+
+    (it "returns error when directory doesn't exist"
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name "list_directory_in_workspace" :arguments (:path "nonexistent")))])
+                 "I tried to list a nonexistent directory"))
+      (let ((callback-called nil)
+            (exit-code nil))
+        (with-temp-buffer
+          (set-visited-file-name project-file)
+          (macher-test--send
+           'macher-ro "Test prompt"
+           (lambda (cb-exit-code cb-fsm)
+             (setq callback-called t)
+             (setq exit-code cb-exit-code)))
+
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+
+          (expect callback-called :to-be-truthy)
+
+          ;; Check that received-requests contains a tool response with error message
+          (let* ((requests (funcall received-requests))
+                 (tool-messages (funcall messages-of-type requests "tool")))
+            (expect (length tool-messages) :to-be 2)
+            (expect (car tool-messages) :to-be nil)
+            (let ((error-message (cadr tool-messages)))
+              (expect (length error-message) :to-be 1)
+              (expect
+               "Directory .nonexistent. not found"
+               :to-appear-once-in (car error-message))))))))
+
+  (describe "patch generation"
     (it "does not generate a patch when no changes are made"
       (funcall setup-backend '("No changes needed."))
       (funcall setup-project "empty-patch")

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -1115,7 +1115,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
               (expect
                ;; When a tool raises an error, the quotes in the formatted string that gets returned
                ;; apper to get changed, e.g. ' -> `.
-               "File .non-existent-file\.txt. not found in workspace"
+               "File .non-existent-file.txt. not found in workspace"
                :to-appear-once-in (car error-message)))))))
 
     (it "generates proper diff when file is deleted"
@@ -1399,7 +1399,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
             (let ((error-message (cadr tool-messages)))
               (expect (length error-message) :to-be 1)
               (expect
-               "File .non-existent\.txt. not found in workspace"
+               "File .non-existent.txt. not found in workspace"
                :to-appear-once-in (car error-message)))))))
 
     (it "returns error when destination already exists"
@@ -1439,7 +1439,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
             (let ((error-message (cadr tool-messages)))
               (expect (length error-message) :to-be 1)
               (expect
-               "Destination .other-file\.txt. already exists"
+               "Destination .other-file.txt. already exists"
                :to-appear-once-in (car error-message)))))))
 
     (it "generates proper diff when file is moved"

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -36,17 +36,7 @@
     (lambda ()
       (when file
         (error "File already created"))
-      (setq file (make-temp-file "macher-test-file" nil ".txt"))))
-
-   ;; Helper to check that directories are absolute and differ only by a trailing slash.
-   (expect-dirs-match
-    (lambda (dir1 dir2)
-      (expect (file-name-absolute-p dir1) :to-be-truthy)
-      (expect (file-name-absolute-p dir2) :to-be-truthy)
-      (expect (file-directory-p dir1) :to-be-truthy)
-      (expect (file-directory-p dir2) :to-be-truthy)
-
-      (expect (expand-file-name "test" dir1) :to-equal (expand-file-name "test" dir2)))))
+      (setq file (make-temp-file "macher-test-file" nil ".txt")))))
 
   (before-all
     ;; Recognize temporary projects.
@@ -81,7 +71,7 @@
     (before-each
       (setq context (macher--make-context))
       (setq temp-file (make-temp-file "macher-test"))
-      ;; Write some test content to the file
+      ;; Write some test content to the file.
       (with-temp-buffer
         (insert "test file content")
         (write-region (point-min) (point-max) temp-file)))
@@ -97,7 +87,7 @@
       (expect (cdr contents) :to-be-truthy) ;; New content should exist.
       (expect (stringp (car contents)) :to-be-truthy)
       (expect (stringp (cdr contents)) :to-be-truthy)
-      ;; Both should initially contain the same content
+      ;; Both should initially contain the same content.
       (expect (car contents) :to-equal "test file content")
       (expect (cdr contents) :to-equal "test file content"))
 
@@ -124,7 +114,7 @@
     (before-each
       (setq context (macher--make-context))
       (setq temp-file (make-temp-file "macher-test"))
-      ;; Write some test content to the file
+      ;; Write some test content to the file.
       (with-temp-buffer
         (insert "original file content")
         (write-region (point-min) (point-max) temp-file)))
@@ -250,59 +240,2213 @@
       ;; Verify macher--build-patch was not called.
       (expect #'macher--build-patch :not :to-have-been-called)))
 
+  (describe "macher--read-string"
+    (it "returns full content when no offset or limit specified"
+      (let ((content "line1\nline2\nline3\nline4"))
+        (expect (macher--read-string content) :to-equal content)))
+
+    (it "returns first N lines when only limit is specified"
+      (let ((content "line1\nline2\nline3\nline4"))
+        (expect (macher--read-string content nil 2) :to-equal "line1\nline2")
+        (expect (macher--read-string content nil 1) :to-equal "line1")
+        (expect (macher--read-string content nil 0) :to-equal "")))
+
+    (it "returns lines from offset to end when only offset is specified"
+      (let ((content "line1\nline2\nline3\nline4"))
+        (expect (macher--read-string content 2) :to-equal "line2\nline3\nline4")
+        (expect (macher--read-string content 3) :to-equal "line3\nline4")
+        (expect (macher--read-string content 4) :to-equal "line4")))
+
+    (it "returns specific range when both offset and limit are specified"
+      (let ((content "line1\nline2\nline3\nline4"))
+        (expect (macher--read-string content 2 2) :to-equal "line2\nline3")
+        (expect (macher--read-string content 1 1) :to-equal "line1")
+        (expect (macher--read-string content 3 1) :to-equal "line3")))
+
+    (it "handles limit larger than total lines"
+      (let ((content "line1\nline2"))
+        (expect (macher--read-string content nil 5) :to-equal "line1\nline2")))
+
+    (it "handles offset larger than total lines"
+      (let ((content "line1\nline2"))
+        (expect (macher--read-string content 5) :to-equal "")))
+
+    (it "handles offset and limit beyond content bounds"
+      (let ((content "line1\nline2"))
+        (expect (macher--read-string content 2 5) :to-equal "line2")
+        (expect (macher--read-string content 3 2) :to-equal "")))
+
+    (it "handles empty content"
+      (let ((content ""))
+        (expect (macher--read-string content) :to-equal "")
+        (expect (macher--read-string content nil 5) :to-equal "")
+        (expect (macher--read-string content 1) :to-equal "")
+        (expect (macher--read-string content 1 3) :to-equal "")))
+
+    (it "handles single line content"
+      (let ((content "single line"))
+        (expect (macher--read-string content nil 1) :to-equal "single line")
+        (expect (macher--read-string content 1) :to-equal "single line")
+        (expect (macher--read-string content 1 1) :to-equal "single line")))
+
+    (it "handles content with trailing newlines"
+      (let ((content "line1\nline2\n"))
+        (expect (macher--read-string content nil 1) :to-equal "line1")
+        (expect (macher--read-string content 2 1) :to-equal "line2")
+        (expect (macher--read-string content 3 1) :to-equal "")))
+
+    (it "handles zero offset (treats as 1)"
+      (let ((content "line1\nline2\nline3"))
+        (expect (macher--read-string content 0) :to-equal "line1\nline2\nline3")
+        (expect (macher--read-string content 0 2) :to-equal "line1\nline2")))
+
+    (describe "negative offset/limit handling"
+      (it "handles negative offset (counts from end)"
+        (let ((content "line1\nline2\nline3\nline4"))
+          ;; -1 means start at 1 line before the end (line4)
+          (expect (macher--read-string content -1) :to-equal "line4")
+          ;; -2 means start at 2 lines before the end (line3)
+          (expect (macher--read-string content -2) :to-equal "line3\nline4")
+          ;; -3 means start at 3 lines before the end (line2)
+          (expect (macher--read-string content -3) :to-equal "line2\nline3\nline4")
+          ;; -4 means start at 4 lines before the end (line1)
+          (expect (macher--read-string content -4) :to-equal "line1\nline2\nline3\nline4")
+          ;; -5 (beyond bounds) should start at beginning
+          (expect (macher--read-string content -5) :to-equal "line1\nline2\nline3\nline4")))
+
+      (it "handles negative limit (counts from total)"
+        (let ((content "line1\nline2\nline3\nline4"))
+          ;; -1 means limit = 4 - 1 = 3 lines
+          (expect (macher--read-string content nil -1) :to-equal "line1\nline2\nline3")
+          ;; -2 means limit = 4 - 2 = 2 lines
+          (expect (macher--read-string content nil -2) :to-equal "line1\nline2")
+          ;; -3 means limit = 4 - 3 = 1 line
+          (expect (macher--read-string content nil -3) :to-equal "line1")
+          ;; -4 means limit = 4 - 4 = 0 lines
+          (expect (macher--read-string content nil -4) :to-equal "")
+          ;; -5 (beyond bounds) should result in 0 lines
+          (expect (macher--read-string content nil -5) :to-equal "")))
+
+      (it "handles negative offset and limit together"
+        (let ((content "line1\nline2\nline3\nline4\nline5"))
+          ;; Start at -2 (line4) and read -2 lines (5 - 2 = 3 lines)
+          (expect (macher--read-string content -2 -2) :to-equal "line4\nline5")
+          ;; Start at -3 (line3) and read -3 lines (5 - 3 = 2 lines)
+          (expect (macher--read-string content -3 -3) :to-equal "line3\nline4")
+          ;; Start at -1 (line5) and read -4 lines (5 - 4 = 1 line)
+          (expect (macher--read-string content -1 -4) :to-equal "line5")))
+
+      (it "handles mixed positive and negative values"
+        (let ((content "line1\nline2\nline3\nline4\nline5"))
+          ;; Start at positive offset 2 (line2) and read -2 lines (5 - 2 = 3 lines)
+          (expect (macher--read-string content 2 -2) :to-equal "line2\nline3\nline4")
+          ;; Start at negative offset -3 (line3) and read positive 2 lines
+          (expect (macher--read-string content -3 2) :to-equal "line3\nline4")))
+
+      (it "handles edge cases for negative values"
+        (let ((content "line1\nline2"))
+          ;; Negative offset beyond bounds
+          (expect (macher--read-string content -10) :to-equal "line1\nline2")
+          ;; Negative limit beyond bounds
+          (expect (macher--read-string content nil -10) :to-equal "")
+          ;; Negative offset and limit both beyond bounds
+          (expect (macher--read-string content -10 -10) :to-equal "")))
+
+      (it "handles empty content with negative values"
+        (let ((content ""))
+          (expect (macher--read-string content -1) :to-equal "")
+          (expect (macher--read-string content nil -1) :to-equal "")
+          (expect (macher--read-string content -1 -1) :to-equal "")))
+
+      (it "handles single line content with negative values"
+        (let ((content "single line"))
+          ;; -1 offset should give the single line
+          (expect (macher--read-string content -1) :to-equal "single line")
+          ;; -1 limit should give 1 - 1 = 0 lines
+          (expect (macher--read-string content nil -1) :to-equal "")
+          ;; -1 offset and -1 limit together
+          (expect (macher--read-string content -1 -1) :to-equal "")))
+
+      (it "handles content with trailing newlines and negative offset/limit"
+        (let ((content "line1\nline2\nline3\n")) ;; Note trailing newline
+          ;; -1 offset should give the empty last "line" after the trailing newline
+          (expect (macher--read-string content -1) :to-equal "")
+          ;; -2 offset should give line3 + trailing newline
+          (expect (macher--read-string content -2) :to-equal "line3\n")
+          ;; -3 offset should give line2 + line3 + trailing newline
+          (expect (macher--read-string content -3) :to-equal "line2\nline3\n")
+          ;; -1 limit should give 4 - 1 = 3 lines (including the empty trailing line)
+          (expect (macher--read-string content nil -1) :to-equal "line1\nline2\nline3")
+          ;; -2 limit should give 4 - 2 = 2 lines
+          (expect (macher--read-string content nil -2) :to-equal "line1\nline2")
+          ;; Combine negative offset and limit with trailing newline
+          (expect (macher--read-string content -2 -3) :to-equal "line3")))
+
+      (it "handles multiple trailing newlines with negative offset/limit"
+        (let ((content "line1\nline2\n\n\n")) ;; Multiple trailing newlines
+          ;; -1 offset should give the last empty line
+          (expect (macher--read-string content -1) :to-equal "")
+          ;; -2 offset should give the second-to-last empty line and the last
+          (expect (macher--read-string content -2) :to-equal "\n")
+          ;; -3 offset should give empty line + empty line + empty line
+          (expect (macher--read-string content -3) :to-equal "\n\n")
+          ;; -4 offset should give line2 + all trailing newlines
+          (expect (macher--read-string content -4) :to-equal "line2\n\n\n")
+          ;; -1 limit should give 5 - 1 = 4 lines
+          (expect (macher--read-string content nil -1) :to-equal "line1\nline2\n\n")
+          ;; -2 limit should give 5 - 2 = 3 lines
+          (expect (macher--read-string content nil -2) :to-equal "line1\nline2\n")
+          ;; Combine negative offset and limit
+          (expect (macher--read-string content -3 -4) :to-equal "")))
+
+      (it "handles content that ends without newline and negative offset/limit"
+        (let ((content "line1\nline2\nline3")) ;; No trailing newline
+          ;; -1 offset should give line3
+          (expect (macher--read-string content -1) :to-equal "line3")
+          ;; -2 offset should give line2 + line3
+          (expect (macher--read-string content -2) :to-equal "line2\nline3")
+          ;; -1 limit should give 3 - 1 = 2 lines
+          (expect (macher--read-string content nil -1) :to-equal "line1\nline2")
+          ;; -2 limit should give 3 - 2 = 1 line
+          (expect (macher--read-string content nil -2) :to-equal "line1")))
+
+      (it "handles single line with trailing newline and negative offset/limit"
+        (let ((content "single line\n")) ;; Single line with trailing newline
+          ;; -1 offset should give the empty line after the newline
+          (expect (macher--read-string content -1) :to-equal "")
+          ;; -2 offset should give the single line + newline
+          (expect (macher--read-string content -2) :to-equal "single line\n")
+          ;; -1 limit should give 2 - 1 = 1 line
+          (expect (macher--read-string content nil -1) :to-equal "single line")
+          ;; -2 limit should give 2 - 2 = 0 lines
+          (expect (macher--read-string content nil -2) :to-equal "")
+          ;; Combine negative offset and limit
+          (expect (macher--read-string content -1 -1) :to-equal ""))))
+
+    (describe "numbered parameter support"
+      (it "returns content with line numbers when numbered is true"
+        (let ((content "line1\nline2\nline3\nline4"))
+          (expect
+           (macher--read-string content nil nil t)
+           :to-equal "1\tline1\n2\tline2\n3\tline3\n4\tline4")))
+
+      (it "handles single line content with numbered parameter"
+        (let ((content "single line"))
+          (expect (macher--read-string content nil nil t) :to-equal "1\tsingle line")))
+
+      (it "handles empty content with numbered parameter"
+        (let ((content ""))
+          (expect (macher--read-string content nil nil t) :to-equal "1\t")))
+
+      (it "doesn't number the trailing newline, if any"
+        (let ((content "line1\nline2\n"))
+          (expect (macher--read-string content nil nil t) :to-equal "1\tline1\n2\tline2\n")))
+
+      (it "combines numbered parameter with offset"
+        (let ((content "line1\nline2\nline3\nline4"))
+          (expect (macher--read-string content 2 nil t) :to-equal "2\tline2\n3\tline3\n4\tline4")))
+
+      (it "combines numbered parameter with limit"
+        (let ((content "line1\nline2\nline3\nline4"))
+          (expect (macher--read-string content nil 2 t) :to-equal "1\tline1\n2\tline2")))
+
+      (it "combines numbered parameter with both offset and limit"
+        (let ((content "line1\nline2\nline3\nline4"))
+          (expect (macher--read-string content 2 2 t) :to-equal "2\tline2\n3\tline3")))
+
+      (it "correctly formats line numbers with proper spacing for content with 100+ lines"
+        (let* ((lines (cl-loop for i from 1 to 105 collect (format "line%d" i)))
+               (content (string-join lines "\n")))
+          (let ((result (macher--read-string content nil nil t)))
+            ;; Should have proper spacing for all line numbers.
+            (expect result :to-match "^  2\tline2\n")
+            (expect result :to-match "^ 99\tline99\n")
+            (expect result :to-match "^100\tline100\n")
+            (expect result :to-match "^101\tline101\n")
+            (expect result :to-match "^105\tline105$")
+            (let ((lines (split-string result "\n")))
+              (expect (length lines) :to-equal 105)
+              ;; Check that all lines have the same format with proper alignment.
+              (dolist (line lines)
+                (when (not (string-empty-p line))
+                  ;; Each line should have the format: "NNN\tlineNNN" where NNN is right-aligned.
+                  (expect line :to-match "^[ 0-9]+\t")
+                  ;; The tab should be at the same position for all lines (after 3 characters for 3-digit max).
+                  (expect (string-match "\t" line) :to-equal 3)))))))
+
+      (it "handles negative offset with numbered parameter"
+        (let ((content "line1\nline2\nline3\nline4"))
+          ;; -2 offset should start at line3 (3rd line) and show line numbers 3 and 4
+          (expect (macher--read-string content -2 nil t) :to-equal "3\tline3\n4\tline4")))
+
+      (it "handles negative limit with numbered parameter"
+        (let ((content "line1\nline2\nline3\nline4"))
+          ;; -2 limit should show first 4-2=2 lines with line numbers 1 and 2
+          (expect (macher--read-string content nil -2 t) :to-equal "1\tline1\n2\tline2")))
+
+      (it "maintains proper spacing for line numbers when using different ranges"
+        (let* ((lines (cl-loop for i from 1 to 50 collect (format "content%d" i)))
+               (content (string-join lines "\n")))
+          ;; Test different ranges to ensure spacing is calculated correctly for each range
+
+          ;; Range 1-9: single digits, should use 1 character width
+          (let ((result1 (macher--read-string content 1 9 t)))
+            (expect result1 :to-match "^1\tcontent1\n")
+            (expect result1 :to-match "^9\tcontent9$")
+            (expect (string-match "\t" result1) :to-equal 1))
+
+          ;; Range 5-15: spans single to double digits, should use 2 character width
+          (let ((result2 (macher--read-string content 5 11 t)))
+            (expect result2 :to-match "^ 5\tcontent5\n")
+            (expect result2 :to-match "^ 9\tcontent9\n")
+            (expect result2 :to-match "^10\tcontent10\n")
+            (expect result2 :to-match "^15\tcontent15$")
+            ;; All tabs should be at position 2 (after 2 characters)
+            (let ((lines (split-string result2 "\n")))
+              (dolist (line lines)
+                (when (not (string-empty-p line))
+                  (expect (string-match "\t" line) :to-equal 2))))))))
+
+    (describe "trailing newline behavior"
+      (it "preserves original string exactly when no parameters specified"
+        ;; No parameters = return original string unchanged
+        (let ((content-with-newline "line1\nline2\n"))
+          (expect (macher--read-string content-with-newline) :to-equal "line1\nline2\n"))
+        (let ((content-without-newline "line1\nline2"))
+          (expect (macher--read-string content-without-newline) :to-equal "line1\nline2")))
+
+      (it "preserves trailing newline behavior with offset-only"
+        ;; Offset only = shouldn't affect trailing newline presence
+        (let ((content-with-newline "line1\nline2\nline3\n"))
+          (expect (macher--read-string content-with-newline 2) :to-equal "line2\nline3\n"))
+        (let ((content-without-newline "line1\nline2\nline3"))
+          (expect (macher--read-string content-without-newline 2) :to-equal "line2\nline3")))
+
+      (it "removes trailing newline with limit parameter by default"
+        ;; Limit parameter = no trailing newline unless it's part of the limited content
+        (let ((content "line1\nline2\nline3\nline4"))
+          (expect (macher--read-string content nil 2) :to-equal "line1\nline2")
+          (expect (macher--read-string content nil 3) :to-equal "line1\nline2\nline3"))
+        ;; But if the original content's trailing newline is within the limit, include it
+        (let ((content-with-newline "line1\nline2\nline3\n"))
+          (expect (macher--read-string content-with-newline nil 3) :to-equal "line1\nline2\nline3")
+          (expect
+           (macher--read-string content-with-newline nil 4)
+           :to-equal "line1\nline2\nline3\n")))
+
+      (it "handles trailing newline with offset and limit combined"
+        ;; Combined offset+limit = same limit behavior applies
+        (let ((content "line1\nline2\nline3\nline4"))
+          (expect (macher--read-string content 2 2) :to-equal "line2\nline3"))
+        (let ((content-with-newline "line1\nline2\nline3\n"))
+          (expect (macher--read-string content-with-newline 2 2) :to-equal "line2\nline3")
+          (expect (macher--read-string content-with-newline 2 3) :to-equal "line2\nline3\n")))
+
+      (it "handles multiple trailing newlines correctly"
+        ;; Multiple trailing newlines
+        (let ((content "line1\nline2\n\n\n"))
+          ;; All lines without limit = preserve all trailing newlines
+          (expect (macher--read-string content) :to-equal "line1\nline2\n\n\n")
+          ;; With limit = include trailing newlines only if within limit
+          (expect (macher--read-string content nil 2) :to-equal "line1\nline2")
+          (expect (macher--read-string content nil 3) :to-equal "line1\nline2\n")
+          (expect (macher--read-string content nil 4) :to-equal "line1\nline2\n\n")
+          (expect (macher--read-string content nil 5) :to-equal "line1\nline2\n\n\n")))
+
+      (it "handles empty lines at end vs trailing newlines"
+        ;; Distinguish between empty lines and trailing newlines
+        (let ((content-empty-line "line1\nline2\n"))
+          (expect (macher--read-string content-empty-line nil 2) :to-equal "line1\nline2")
+          (expect (macher--read-string content-empty-line nil 3) :to-equal "line1\nline2\n"))
+        (let ((content-empty-lines "line1\nline2\n\n"))
+          (expect (macher--read-string content-empty-lines nil 2) :to-equal "line1\nline2")
+          (expect (macher--read-string content-empty-lines nil 3) :to-equal "line1\nline2\n")
+          (expect (macher--read-string content-empty-lines nil 4) :to-equal "line1\nline2\n\n")))
+
+      (describe "numbered parameter and trailing newlines"
+        (it "replicates cat -n behavior for trailing newlines"
+          ;; cat -n shows final trailing newline without a number
+          (let ((content "line1\nline2\n"))
+            (expect (macher--read-string content nil nil t) :to-equal "1\tline1\n2\tline2\n"))
+          (let ((content "line1\nline2"))
+            (expect (macher--read-string content nil nil t) :to-equal "1\tline1\n2\tline2")))
+
+        (it "numbers all but the last trailing newline"
+          ;; Multiple trailing newlines: all but the last get numbered
+          (let ((content "line1\nline2\n\n\n"))
+            (expect
+             (macher--read-string content nil nil t)
+             :to-equal "1\tline1\n2\tline2\n3\t\n4\t\n"))
+          (let ((content "line1\n\n\n"))
+            (expect (macher--read-string content nil nil t) :to-equal "1\tline1\n2\t\n3\t\n")))
+
+        (it "numbers blank lines in middle of content"
+          ;; Blank lines in the middle always get numbered
+          (let ((content "line1\n\nline3\n"))
+            (expect (macher--read-string content nil nil t) :to-equal "1\tline1\n2\t\n3\tline3\n"))
+          (let ((content "line1\n\n\nline4"))
+            (expect
+             (macher--read-string content nil nil t)
+             :to-equal "1\tline1\n2\t\n3\t\n4\tline4")))
+
+        (it "numbers blank lines in the middle of the content, even if at the end of the limit"
+          ;; When limit cuts off content, "trailing" newlines in the middle get numbered.
+          (let ((content "line1\nline2\n\nline4\nline5"))
+            (expect (macher--read-string content nil 3 t) :to-equal "1\tline1\n2\tline2\n3\t")
+            (expect
+             (macher--read-string content nil 4 t)
+             :to-equal "1\tline1\n2\tline2\n3\t\n4\tline4")))
+
+        (it "combines numbered with offset and doesn't number trailing newlines"
+          ;; Numbered with offset should still follow cat -n behavior.
+          (let ((content "line1\nline2\nline3\n"))
+            (expect (macher--read-string content 2 nil t) :to-equal "2\tline2\n3\tline3\n"))
+          (let ((content "line1\nline2\nline3"))
+            (expect (macher--read-string content 2 nil t) :to-equal "2\tline2\n3\tline3")))
+
+        (it "combines numbered with limit and doesn't number trailing newlines"
+          ;; With trailing newline.
+          (let ((content "line1\nline2\nline3\nline4\n"))
+            (expect (macher--read-string content nil 3 t) :to-equal "1\tline1\n2\tline2\n3\tline3")
+            (expect
+             (macher--read-string content nil 4 t)
+             :to-equal "1\tline1\n2\tline2\n3\tline3\n4\tline4")
+            (expect
+             (macher--read-string content nil 5 t)
+             :to-equal "1\tline1\n2\tline2\n3\tline3\n4\tline4\n"))
+
+          ;; No trailing newline.
+          (let ((content "line1\nline2\nline3"))
+            (expect
+             (macher--read-string content nil 4 t)
+             :to-equal "1\tline1\n2\tline2\n3\tline3"))))))
+
   (describe "macher--edit-string"
-    (it "replaces single occurrence of old text with new text"
-      (let* ((content "Hello world! This is a test.")
-             (old-text "world")
-             (new-text "universe")
-             (result (macher--edit-string content old-text new-text)))
-        (expect result :to-equal "Hello universe! This is a test.")))
+    (describe "basic replacement behavior"
+      (it "replaces single occurrence of old text with new text"
+        (let* ((content "Hello world! This is a test.")
+               (old-text "world")
+               (new-text "universe")
+               (result (macher--edit-string content old-text new-text)))
+          (expect result :to-equal "Hello universe! This is a test.")))
 
-    (it "handles empty old string in empty content"
-      (let* ((content "")
-             (old-text "")
-             (new-text "new content")
-             (result (macher--edit-string content old-text new-text)))
-        (expect result :to-equal "new content")))
+      (it "handles multiline content correctly"
+        (let* ((content "Line 1\nLine 2\nLine 3")
+               (old-text "Line 2")
+               (new-text "Modified Line 2")
+               (result (macher--edit-string content old-text new-text)))
+          (expect result :to-equal "Line 1\nModified Line 2\nLine 3")))
 
-    (it "signals error for empty old string in non-empty content"
-      (let ((content "some content")
-            (old-text "")
-            (new-text "replacement"))
-        (expect (macher--edit-string content old-text new-text) :to-throw)))
+      (it "replaces entire content when old text matches everything"
+        (let* ((content "complete content")
+               (old-text "complete content")
+               (new-text "new content")
+               (result (macher--edit-string content old-text new-text)))
+          (expect result :to-equal "new content")))
 
-    (it "signals error when old text is not found"
-      (let ((content "Hello world!")
-            (old-text "missing")
-            (new-text "replacement"))
-        (expect (macher--edit-string content old-text new-text) :to-throw)))
+      (it "handles empty new text (deletion)"
+        (let* ((content "Remove this word from sentence")
+               (old-text "this word ")
+               (new-text "")
+               (result (macher--edit-string content old-text new-text)))
+          (expect result :to-equal "Remove from sentence"))))
 
-    (it "signals error when old text appears multiple times"
-      (let ((content "test test test")
-            (old-text "test")
-            (new-text "replacement"))
-        (expect (macher--edit-string content old-text new-text) :to-throw)))
+    (describe "error conditions"
+      (it "signals error when old_string and new_string are identical"
+        (let ((content "Hello world")
+              (old-text "world")
+              (new-text "world"))
+          (expect (macher--edit-string content old-text new-text) :to-throw)))
 
-    (it "handles multiline content correctly"
-      (let* ((content "Line 1\nLine 2\nLine 3")
-             (old-text "Line 2")
-             (new-text "Modified Line 2")
-             (result (macher--edit-string content old-text new-text)))
-        (expect result :to-equal "Line 1\nModified Line 2\nLine 3")))
+      (it "signals error when old_string is not found"
+        (let ((content "Hello world")
+              (old-text "missing")
+              (new-text "replacement"))
+          (expect (macher--edit-string content old-text new-text) :to-throw)))
 
-    (it "replaces entire content when old text matches everything"
-      (let* ((content "complete content")
-             (old-text "complete content")
-             (new-text "new content")
-             (result (macher--edit-string content old-text new-text)))
-        (expect result :to-equal "new content")))
+      (it "signals error when multiple matches exist without replace-all"
+        (let ((content "hello world hello universe")
+              (old-text "hello")
+              (new-text "hi"))
+          (expect (macher--edit-string content old-text new-text) :to-throw))))
 
-    (it "handles empty new text (deletion)"
-      (let* ((content "Remove this word from sentence")
-             (old-text "this word ")
-             (new-text "")
-             (result (macher--edit-string content old-text new-text)))
-        (expect result :to-equal "Remove from sentence"))))
+    (describe "exact whitespace matching"
+      (it "requires exact whitespace match"
+        (let* ((content "  function test() {\n    return 'hello';\n  }")
+               (old-text "function test() {\n  return 'hello';\n}")
+               (new-text "function test() {\n  return 'world';\n}"))
+          ;; Should fail because whitespace doesn't match exactly.
+          (expect (macher--edit-string content old-text new-text) :to-throw)))
+
+      (it "succeeds with exact whitespace match"
+        (let* ((content "  function test() {\n    return 'hello';\n  }")
+               (old-text "  function test() {\n    return 'hello';\n  }")
+               (new-text "  function test() {\n    return 'world';\n  }")
+               (result (macher--edit-string content old-text new-text)))
+          (expect result :to-equal "  function test() {\n    return 'world';\n  }")))
+
+      (it "handles tabs and spaces exactly"
+        (let* ((content "\tfunction test() {\n\t  return 'hello';\n\t}")
+               (old-text "\tfunction test() {\n\t  return 'hello';\n\t}")
+               (new-text "\tfunction test() {\n\t  return 'world';\n\t}")
+               (result (macher--edit-string content old-text new-text)))
+          (expect result :to-equal "\tfunction test() {\n\t  return 'world';\n\t}")))
+
+      (it "fails when indentation differs"
+        (let* ((content "    function test() {\n      return 'hello';\n    }")
+               (old-text "  function test() {\n    return 'hello';\n  }")
+               (new-text "  function test() {\n    return 'world';\n  }"))
+          (expect (macher--edit-string content old-text new-text) :to-throw))))
+
+    (describe "replace-all functionality"
+      (it "replaces all occurrences when replace-all is true"
+        (let* ((content "hello world hello universe hello there")
+               (old-text "hello")
+               (new-text "hi")
+               (result (macher--edit-string content old-text new-text t)))
+          (expect result :to-equal "hi world hi universe hi there")))
+
+      (it "replaces all occurrences in multiline content"
+        (let* ((content "hello world\nhello universe\nhello there")
+               (old-text "hello")
+               (new-text "hi")
+               (result (macher--edit-string content old-text new-text t)))
+          (expect result :to-equal "hi world\nhi universe\nhi there")))
+
+      (it "handles replace-all with exact whitespace matching"
+        (let* ((content "  hello world\n  hello universe\n  hello there")
+               (old-text "  hello")
+               (new-text "  hi")
+               (result (macher--edit-string content old-text new-text t)))
+          (expect result :to-equal "  hi world\n  hi universe\n  hi there")))
+
+      (it "replace-all works with single occurrence"
+        (let* ((content "hello world")
+               (old-text "hello")
+               (new-text "hi")
+               (result (macher--edit-string content old-text new-text t)))
+          (expect result :to-equal "hi world"))))
+
+    (describe "function signature compatibility"
+      (it "accepts replace-all parameter as fourth argument"
+        (let* ((content "hello world hello universe")
+               (old-text "hello")
+               (new-text "hi"))
+          ;; Should error when multiple matches exist without replace-all.
+          (expect (macher--edit-string content old-text new-text nil) :to-throw)
+          ;; Should replace all when replace-all is true.
+          (let ((result (macher--edit-string content old-text new-text t)))
+            (expect result :to-equal "hi world hi universe"))))
+
+      (it "works with default behavior when replace-all is omitted"
+        (let* ((content "hello world")
+               (old-text "hello")
+               (new-text "hi")
+               (result (macher--edit-string content old-text new-text)))
+          (expect result :to-equal "hi world"))))
+
+
+    (describe "literal string matching (no regex support)"
+      (it "treats oldText as literal string, not regex pattern"
+        (let* ((content "function test() { return /hello/; }")
+               (old-text "/hello/") ;; This looks like regex but should be treated literally
+               (new-text "/world/")
+               (result (macher--edit-string content old-text new-text)))
+          ;; Should match the literal string "/hello/", not as regex
+          (expect result :to-equal "function test() { return /world/; }")))
+
+      (it "handles special regex characters as literal"
+        (let* ((content "price is $100 (approx)")
+               (old-text "$100") ;; $ is regex metacharacter but should be literal
+               (new-text "$200")
+               (result (macher--edit-string content old-text new-text)))
+          ;; Should match the literal string "$100", not as regex
+          (expect result :to-equal "price is $200 (approx)")))
+
+      (it "handles brackets as literal characters"
+        (let* ((content "array[0] = value")
+               ;; Brackets are regex metacharacters but should be literal.
+               (old-text "array[0]")
+               (new-text "list[0]")
+               (result (macher--edit-string content old-text new-text)))
+          ;; Should match the literal string "array[0]", not as regex.
+          (expect result :to-equal "list[0] = value")))))
+
+  (describe "macher--format-size"
+    (it "formats bytes correctly"
+      (expect (macher--format-size 0) :to-equal "0 B")
+      (expect (macher--format-size 512) :to-equal "512 B")
+      (expect (macher--format-size 1024) :to-equal "1.0 KB")
+      (expect (macher--format-size 1536) :to-equal "1.5 KB")
+      (expect (macher--format-size 1048576) :to-equal "1.0 MB")
+      (expect (macher--format-size 1073741824) :to-equal "1.0 GB")))
+
+  (describe "macher--tool-list-directory"
+    :var (context temp-dir)
+
+    (before-each
+      (setq temp-dir (make-temp-file "macher-test-dir" t))
+      (setq context
+            (macher--make-context :workspace (cons 'project (file-name-as-directory temp-dir))))
+      ;; Create test directory structure.
+      (make-directory (expand-file-name "subdir" temp-dir))
+      (make-directory (expand-file-name "subdir/nested" temp-dir))
+      (write-region "file1 content" nil (expand-file-name "file1.txt" temp-dir))
+      (write-region "file2 content" nil (expand-file-name "file2.el" temp-dir))
+      (write-region "nested file content" nil (expand-file-name "subdir/nested/file.txt" temp-dir))
+
+      ;; Add the project marker.
+      (write-region "" nil (expand-file-name ".project" temp-dir)))
+
+    (after-each
+      (when (and temp-dir (file-exists-p temp-dir))
+        (delete-directory temp-dir t)))
+
+    (it "lists directory contents without recursion or sizes"
+      (let ((result (macher--tool-list-directory context ".")))
+        (expect result :to-match "file: file1.txt")
+        (expect result :to-match "file: file2.el")
+        (expect result :to-match "dir: subdir")
+        (expect result :not :to-match "nested")))
+
+    (it "lists directory contents with sizes"
+      (let ((result (macher--tool-list-directory context "." nil t)))
+        (expect result :to-match "file: file1.txt (13 B)")
+        (expect result :to-match "file: file2.el (13 B)")
+        ;; No size for directories.
+        (expect result :to-match "dir: subdir$")))
+
+    (it "lists directory contents recursively"
+      (let ((result (macher--tool-list-directory context "." t)))
+        (expect result :to-match "file: file1.txt")
+        (expect result :to-match "file: file2.el")
+        (expect result :to-match "dir: subdir")
+        (expect result :to-match "  dir: subdir/nested")
+        (expect result :to-match "    file: subdir/nested/file.txt")))
+
+    (it "lists directory contents recursively with sizes"
+      (let ((result (macher--tool-list-directory context "." t t)))
+        (expect result :to-match "file: file1.txt (13 B)")
+        (expect result :to-match "file: file2.el (13 B)")
+        (expect result :to-match "dir: subdir$")
+        (expect result :to-match "  dir: subdir/nested$")
+        (expect result :to-match "    file: subdir/nested/file.txt (19 B)")))
+
+    (it "lists subdirectory contents"
+      (let ((result (macher--tool-list-directory context "subdir")))
+        (expect result :to-match "dir: nested")
+        (expect result :not :to-match "file1.txt")
+        (expect result :not :to-match "file2.el")))
+
+    (it "handles empty directories"
+      (let ((empty-dir (expand-file-name "empty" temp-dir)))
+        (make-directory empty-dir)
+        (let ((result (macher--tool-list-directory context "empty")))
+          (expect result :to-equal "Directory is empty"))))
+
+    (it "takes macher context into account - shows created files"
+      ;; Create a file in the macher context.
+      (macher-context--set-new-content-for-file
+       (expand-file-name "new-file.txt" temp-dir) "new content" context)
+      (let ((result (macher--tool-list-directory context ".")))
+        (expect result :to-match "file: new-file.txt")))
+
+    (it "takes macher context into account - hides deleted files"
+      ;; Delete a file in the macher context.
+      (macher-context--set-new-content-for-file (expand-file-name "file1.txt" temp-dir) nil context)
+      (let ((result (macher--tool-list-directory context ".")))
+        (expect result :not :to-match "file1.txt")
+        (expect result :to-match "file: file2.el")))
+
+    (it "takes macher context into account - shows correct sizes for modified files"
+      ;; Modify a file in the macher context.
+      (let ((longer-content "modified content that is longer"))
+        (macher-context--set-new-content-for-file
+         (expand-file-name "file1.txt" temp-dir) longer-content context)
+        (let ((result (macher--tool-list-directory context "." nil t)))
+          (expect result :to-match (format "file: file1.txt (%d B)" (length longer-content)))
+          (expect result :to-match "file: file2.el (13 B)"))))
+
+    (it "signals error for non-existent directory"
+      (expect (macher--tool-list-directory context "non-existent") :to-throw))
+
+    (it "signals error when path is a file"
+      (expect (macher--tool-list-directory context "file1.txt") :to-throw))
+
+    (it "does not load files into context when listing directories"
+      ;; Create additional subdirectories with files to test with.
+      (let ((subdir2 (expand-file-name "subdir2" temp-dir))
+            (subdir3 (expand-file-name "subdir/subdir3" temp-dir)))
+        (make-directory subdir2)
+        (make-directory subdir3)
+        (write-region "file in subdir2" nil (expand-file-name "file4.txt" subdir2))
+        (write-region "file in nested subdir3" nil (expand-file-name "file5.txt" subdir3))
+
+        ;; Verify context starts empty.
+        (expect (macher-context-contents context) :to-be nil)
+
+        ;; Call list-directory on various directories multiple times.
+        (macher--tool-list-directory context ".")
+        (expect (macher-context-contents context) :to-be nil)
+
+        (macher--tool-list-directory context "subdir")
+        (expect (macher-context-contents context) :to-be nil)
+
+        (macher--tool-list-directory context "subdir2")
+        (expect (macher-context-contents context) :to-be nil)
+
+        ;; Recursive.
+        (macher--tool-list-directory context "subdir" t)
+        (expect (macher-context-contents context) :to-be nil)
+
+        ;; Recursive with sizes.
+        (macher--tool-list-directory context "." t t)
+        (expect (macher-context-contents context) :to-be nil)
+
+        ;; Verify that the context contents remain empty after all calls.
+        (expect (macher-context-contents context) :to-be nil)))
+
+    (it "shows symlinks with special prefix and target"
+      ;; Create a symlink to a file.
+      (let ((symlink-path (expand-file-name "file-symlink" temp-dir))
+            (target-path (expand-file-name "file1.txt" temp-dir)))
+        (make-symbolic-link target-path symlink-path)
+
+        ;; Mock workspace files to include the symlink.
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace) (append (macher--project-files (cdr workspace)) (list symlink-path))))
+
+        (let ((result (macher--tool-list-directory context ".")))
+          (expect result :to-match "link: file-symlink ->")
+          (expect result :to-match "file: file1.txt")
+          (expect result :to-match "file: file2.el"))
+
+        ;; Clean up.
+        (delete-file symlink-path))
+
+      ;; Create a symlink to a directory.
+      (let ((dir-symlink-path (expand-file-name "dir-symlink" temp-dir))
+            (target-dir (expand-file-name "subdir" temp-dir)))
+        (make-symbolic-link target-dir dir-symlink-path)
+
+        ;; Mock workspace files to include the directory symlink
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace)
+           (append (macher--project-files (cdr workspace)) (list dir-symlink-path))))
+
+        (let ((result (macher--tool-list-directory context ".")))
+          (expect result :to-match "link: dir-symlink ->")
+          (expect result :to-match "dir: subdir"))
+
+        ;; Clean up.
+        (delete-file dir-symlink-path))
+
+      ;; Create a broken symlink.
+      (let ((broken-symlink-path (expand-file-name "broken-symlink" temp-dir)))
+        (make-symbolic-link "/nonexistent/target" broken-symlink-path)
+
+        ;; Mock workspace files to include the broken symlink.
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace)
+           (append (macher--project-files (cdr workspace)) (list broken-symlink-path))))
+
+        (let ((result (macher--tool-list-directory context ".")))
+          (expect result :to-match "link: broken-symlink -> /nonexistent/target"))
+
+        ;; Clean up.
+        (delete-file broken-symlink-path)))
+
+    (it "lists contents of directories created through context (new files in non-existent directories)"
+      ;; Test that we can list directories that don't exist on disk but contain new files in the
+      ;; context. This validates the behavior when files are added to directories that didn't yet
+      ;; exist.
+
+      ;; Create a new file in a directory that doesn't exist on disk.
+      (macher-context--set-new-content-for-file
+       (expand-file-name "newdir/newfile.txt" temp-dir) "new file content" context)
+
+      ;; Should be able to list the contents of the new directory.
+      (let ((result (macher--tool-list-directory context "newdir")))
+        (expect result :to-match "file: newfile.txt"))
+
+      ;; Test with multiple nested subdirectories.
+      (macher-context--set-new-content-for-file
+       (expand-file-name "deep/nested/path/file1.txt" temp-dir) "deep file 1" context)
+      (macher-context--set-new-content-for-file
+       (expand-file-name "deep/nested/path/file2.txt" temp-dir) "deep file 2" context)
+      (macher-context--set-new-content-for-file
+       (expand-file-name "deep/nested/other/file3.txt" temp-dir) "deep file 3" context)
+
+      ;; Should be able to list the deeply nested directory.
+      (let ((result (macher--tool-list-directory context "deep/nested/path")))
+        (expect result :to-match "file: file1.txt")
+        (expect result :to-match "file: file2.txt")
+        ;; file3.txt is in ../other/.
+        (expect result :not :to-match "file3.txt"))
+
+      ;; Should be able to list intermediate directories.
+      (let ((result (macher--tool-list-directory context "deep/nested")))
+        (expect result :to-match "dir: path")
+        (expect result :to-match "dir: other"))
+
+      ;; Test recursive listing from root to see the entire structure.
+      (let ((result (macher--tool-list-directory context "." t)))
+        (expect result :to-match "dir: newdir")
+        (expect result :to-match "  file: newdir/newfile.txt")
+        (expect result :to-match "dir: deep")
+        (expect result :to-match "  dir: deep/nested")
+        (expect result :to-match "    dir: deep/nested/path")
+        (expect result :to-match "      file: deep/nested/path/file1.txt")
+        (expect result :to-match "      file: deep/nested/path/file2.txt")
+        (expect result :to-match "    dir: deep/nested/other")
+        (expect result :to-match "      file: deep/nested/other/file3.txt"))
+
+      ;; Test mixed scenario: existing directories with new files.
+      (macher-context--set-new-content-for-file
+       (expand-file-name "subdir/newfile-in-existing-dir.txt" temp-dir) "mixed content" context)
+
+      (let ((result (macher--tool-list-directory context "subdir")))
+        ;; New file.
+        (expect result :to-match "file: newfile-in-existing-dir.txt")
+        ;; Existing directory.
+        (expect result :to-match "dir: nested"))
+
+      ;; Test with sizes for new files.
+      (let ((result (macher--tool-list-directory context "newdir" nil t)))
+        (expect result :to-match "file: newfile.txt (16 B)"))
+
+      ;; Test edge case: empty directory path in deeply nested structure.
+      (macher-context--set-new-content-for-file
+       (expand-file-name "edge/case/deeply/nested/empty.txt" temp-dir) "" context)
+
+      (let ((result (macher--tool-list-directory context "edge/case/deeply/nested" nil t)))
+        (expect result :to-match "file: empty.txt (0 B)")))
+
+    (it "does not list files that aren't in context or workspace files list"
+      ;; Create files on disk that are not included in the workspace's files list.
+      (let ((untracked-file1 (expand-file-name "untracked1.txt" temp-dir))
+            (untracked-file2 (expand-file-name "untracked2.txt" temp-dir))
+            (subdir-untracked (expand-file-name "subdir/untracked-sub.txt" temp-dir)))
+        (write-region "untracked content 1" nil untracked-file1)
+        (write-region "untracked content 2" nil untracked-file2)
+        (write-region "untracked sub content" nil subdir-untracked)
+
+        ;; Mock workspace files to exclude the untracked files from the files list.
+        ;; This simulates files that exist on disk but aren't tracked by the workspace.
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace)
+           ;; Get the actual files from the real function but filter out untracked files.
+           (let ((files (macher--project-files (cdr workspace))))
+             (cl-remove-if
+              (lambda (file)
+                (or (string-match-p "untracked1\\.txt$" file)
+                    (string-match-p "untracked2\\.txt$" file)
+                    (string-match-p "untracked-sub\\.txt$" file)))
+              files))))
+
+        ;; Test that untracked files don't appear in directory listing.
+        (let ((result (macher--tool-list-directory context ".")))
+          ;; Should contain workspace files.
+          (expect result :to-match "file: file1.txt")
+          (expect result :to-match "file: file2.el")
+          (expect result :to-match "dir: subdir")
+          ;; Should NOT contain untracked files.
+          (expect result :not :to-match "untracked1.txt")
+          (expect result :not :to-match "untracked2.txt"))
+
+        ;; Test subdirectory as well.
+        (let ((result (macher--tool-list-directory context "subdir")))
+          ;; Should contain workspace files.
+          (expect result :to-match "dir: nested")
+          ;; Should NOT contain untracked files.
+          (expect result :not :to-match "untracked-sub.txt"))
+
+        ;; However, files in the context (even if not on disk) should appear.
+        (macher-context--set-new-content-for-file
+         (expand-file-name "context-only-file.txt" temp-dir) "context content" context)
+
+        (let ((result (macher--tool-list-directory context ".")))
+          ;; Should show context-only file even though it's not on disk.
+          (expect result :to-match "file: context-only-file.txt")
+          ;; Still should not show untracked disk files.
+          (expect result :not :to-match "untracked1.txt"))
+
+        ;; Test that modified files in context are still shown with correct content size.
+        (let ((modified-content "modified content that is much longer"))
+          (macher-context--set-new-content-for-file
+           (expand-file-name "file1.txt" temp-dir) modified-content context)
+
+          (let ((result (macher--tool-list-directory context "." nil t)))
+            ;; Should show modified file with new content size.
+            (expect result :to-match (format "file: file1.txt (%d B)" (length modified-content)))
+            ;; Still should not show untracked files.
+            (expect result :not :to-match "untracked1.txt")))
+
+        ;; Clean up untracked files.
+        (delete-file untracked-file1)
+        (delete-file untracked-file2)
+        (delete-file subdir-untracked)))
+
+    (it "does not allow listing directories outside the workspace root"
+      ;; Try to list parent directory (should fail).
+      (let ((parent-dir (file-name-directory (directory-file-name temp-dir))))
+        (expect (macher--tool-list-directory context "..") :to-throw))
+
+      ;; Try to list absolute paths outside workspace (should fail).
+      (expect (macher--tool-list-directory context "/etc") :to-throw)
+      (expect (macher--tool-list-directory context "/tmp") :to-throw)
+
+      ;; Try to list using relative paths that escape workspace (should fail).
+      (expect (macher--tool-list-directory context "../..") :to-throw)
+      (expect (macher--tool-list-directory context "../../etc") :to-throw)
+
+      ;; Try to list using paths with .. components that escape (should fail).
+      (expect (macher--tool-list-directory context "subdir/../../..") :to-throw)
+
+      ;; Verify that valid paths within workspace still work.
+      (let ((result (macher--tool-list-directory context ".")))
+        (expect result :to-be-truthy))
+
+      (let ((result (macher--tool-list-directory context "subdir")))
+        (expect result :to-be-truthy)))
+
+    (it "does not allow listing external directories even if they contain workspace files"
+      ;; Create an external directory with a file.
+      (let ((external-dir (make-temp-file "macher-external-test" t))
+            (external-file-name "external-workspace-file.txt"))
+
+        (unwind-protect
+            (progn
+              ;; Create a file in the external directory
+              (let ((external-file (expand-file-name external-file-name external-dir)))
+                (write-region "external file content" nil external-file)
+
+                ;; Mock workspace-files to include the external file in the workspace files list.
+                ;; This simulates a scenario where the workspace configuration incorrectly includes
+                ;; files outside the workspace root.
+                (spy-on
+                 'macher--workspace-files
+                 :and-call-fake
+                 (lambda (workspace)
+                   ;; Get the actual project files and add our external file
+                   (let ((normal-files (macher--project-files (cdr workspace))))
+                     (append normal-files (list external-file)))))
+
+                ;; Even though the external file is in the workspace-files list, we should not be
+                ;; able to list the external directory.
+                (expect (macher--tool-list-directory context external-dir) :to-throw)
+
+                ;; Also test with relative paths that would escape to the external dir.
+                (let ((relative-to-external (file-relative-name external-dir temp-dir)))
+                  (expect (macher--tool-list-directory context relative-to-external) :to-throw))
+
+                ;; Verify that normal workspace operations still work.
+                (let ((result (macher--tool-list-directory context ".")))
+                  (expect result :to-be-truthy))))
+
+          ;; Clean up the external directory
+          (when (file-exists-p external-dir)
+            (delete-directory external-dir t))))))
+
+  (describe "macher--search-get-xref-matches"
+    :var (context temp-dir)
+
+    (describe "basic behavior"
+      (before-each
+        (setq temp-dir (make-temp-file "macher-test-search-dir" t))
+        (setq context
+              (macher--make-context :workspace (cons 'project (file-name-as-directory temp-dir))))
+        ;; Create test directory structure.
+        (make-directory (expand-file-name "subdir" temp-dir))
+        (write-region
+         "hello world\nhello universe\ngoodbye world" nil (expand-file-name "file1.txt" temp-dir))
+        (write-region
+         "hello javascript\nfunction test() {}\nconst x = 1;"
+         nil
+         (expand-file-name "file2.js" temp-dir))
+        (write-region
+         "hello python\ndef test():\n    pass" nil (expand-file-name "subdir/file3.py" temp-dir))
+        (write-region
+         "no matches here\nnothing to find" nil (expand-file-name "file4.txt" temp-dir))
+        ;; Add the project marker.
+        (write-region "" nil (expand-file-name ".project" temp-dir)))
+
+      (after-each
+        (when (and temp-dir (file-exists-p temp-dir))
+          (delete-directory temp-dir t)))
+
+      (it "returns matches alist with correct structure"
+        (let ((result (macher--search-get-xref-matches context "hello")))
+          (expect (listp result) :to-be-truthy)
+          ;; Should have entries for files with matches (relative to workspace root).
+          (expect (assoc "file1.txt" result) :to-be-truthy)
+          (expect (assoc "file2.js" result) :to-be-truthy)
+          (expect (assoc "subdir/file3.py" result) :to-be-truthy)
+          ;; Should not have entries for files without matches.
+          (expect (assoc "file4.txt" result) :to-be nil)))
+
+      (it "handles basic regexp filtering"
+        (let ((result (macher--search-get-xref-matches context "hello" :file-regexp "\\.js$")))
+          (expect (assoc "file2.js" result) :to-be-truthy)
+          (expect (assoc "file1.txt" result) :to-be nil)))
+
+      (it "handles path filtering with results relative to workspace root"
+        (let ((result (macher--search-get-xref-matches context "hello" :path "subdir")))
+          ;; When searching in "subdir", results should still be relative to workspace root (like grep).
+          (expect (assoc "subdir/file3.py" result) :to-be-truthy)
+          ;; Files outside the search directory should not appear.
+          (expect (assoc "file1.txt" result) :to-be nil)
+          (expect (assoc "file3.py" result) :to-be nil)))
+
+      (it "handles context modifications"
+        ;; Modify a file in context.
+        (macher-context--set-new-content-for-file
+         (expand-file-name "file1.txt" temp-dir)
+         "modified hello content\nnew line with hello"
+         context)
+        (let ((result (macher--search-get-xref-matches context "modified")))
+          (expect (assoc "file1.txt" result) :to-be-truthy)))
+
+      (it "shows paths relative to workspace root even when path is specified"
+        (let ((result (macher--search-get-xref-matches context "hello" :path "subdir")))
+          ;; When searching in "subdir", results should still be relative to workspace root (like grep).
+          (expect (assoc "subdir/file3.py" result) :to-be-truthy)
+          ;; Should NOT show paths relative to search directory.
+          (expect (assoc "file3.py" result) :to-be nil)
+          ;; Files outside the search directory should not appear at all.
+          (expect (assoc "file1.txt" result) :to-be nil)
+          (expect (assoc "file2.js" result) :to-be nil)))
+
+      (it "performs case-insensitive search"
+        ;; Create files with mixed case content.
+        (macher-context--set-new-content-for-file
+         (expand-file-name "file1.txt" temp-dir) "Hello World\nthis is HELLO again" context)
+        (macher-context--set-new-content-for-file
+         (expand-file-name "file2.txt" temp-dir) "hello universe\nBYE" context)
+
+        ;; Case-sensitive search should not find uppercase 'HELLO'.
+        (let ((result (macher--search-get-xref-matches context "hello")))
+          (expect (assoc "file1.txt" result) :to-be nil)
+          (expect (length (cdr (assoc "file2.txt" result))) :to-be 1))
+
+        ;; Case-insensitive search should find both.
+        (let ((result (macher--search-get-xref-matches context "hello" :case-insensitive t)))
+          (expect (assoc "file1.txt" result) :to-be-truthy)
+          (expect (length (cdr (assoc "file1.txt" result))) :to-be 2)
+
+          (expect (length (cdr (assoc "file2.txt" result))) :to-be 1))))
+
+    (describe "regexp filtering"
+      :var (context temp-dir)
+
+      (before-each
+        (setq temp-dir (make-temp-file "macher-test-regexp-dir" t))
+        (setq context
+              (macher--make-context :workspace (cons 'project (file-name-as-directory temp-dir))))
+        ;; Create nested directory structure with various file types.
+        (make-directory (expand-file-name "src" temp-dir))
+        (make-directory (expand-file-name "src/components" temp-dir))
+        (make-directory (expand-file-name "tests" temp-dir))
+        (make-directory (expand-file-name "docs" temp-dir))
+
+        ;; Root level files.
+        (write-region "hello root js" nil (expand-file-name "app.js" temp-dir))
+        (write-region "hello root py" nil (expand-file-name "main.py" temp-dir))
+        (write-region "hello root txt" nil (expand-file-name "README.txt" temp-dir))
+
+        ;; src/ level files
+        (write-region "hello src js" nil (expand-file-name "src/utils.js" temp-dir))
+        (write-region "hello src py" nil (expand-file-name "src/helper.py" temp-dir))
+
+        ;; src/components/ level files.
+        (write-region
+         "hello component js" nil (expand-file-name "src/components/button.js" temp-dir))
+        (write-region
+         "hello component ts" nil (expand-file-name "src/components/modal.ts" temp-dir))
+
+        ;; tests/ level files.
+        (write-region "hello test js" nil (expand-file-name "tests/app.test.js" temp-dir))
+        (write-region "hello test py" nil (expand-file-name "tests/test_main.py" temp-dir))
+
+        ;; docs/ level files.
+        (write-region "hello doc md" nil (expand-file-name "docs/guide.md" temp-dir))
+
+        ;; Add the project marker.
+        (write-region "" nil (expand-file-name ".project" temp-dir)))
+
+      (after-each
+        (when (and temp-dir (file-exists-p temp-dir))
+          (delete-directory temp-dir t)))
+
+      (it "handles simple extension regexp at root level only"
+        (let ((result
+               (macher--search-get-xref-matches context "hello" :file-regexp "^[^/]*\\.js$")))
+          ;; Should match only root level .js files (relative to workspace root since no path
+          ;; specified).
+          (expect (assoc "app.js" result) :to-be-truthy)
+          ;; Should NOT match .js files in subdirectories.
+          (expect (assoc "src/utils.js" result) :to-be nil)
+          (expect (assoc "src/components/button.js" result) :to-be nil)
+          (expect (assoc "tests/app.test.js" result) :to-be nil)
+          ;; Should NOT match other extensions.
+          (expect (assoc "main.py" result) :to-be nil)
+          (expect (assoc "README.txt" result) :to-be nil)))
+
+      (it "handles recursive extension regexp across all directories"
+        (let ((result (macher--search-get-xref-matches context "hello" :file-regexp "\\.js$")))
+          ;; Should match .js files at all levels.
+          (expect (assoc "app.js" result) :to-be-truthy)
+          (expect (assoc "src/utils.js" result) :to-be-truthy)
+          (expect (assoc "src/components/button.js" result) :to-be-truthy)
+          (expect (assoc "tests/app.test.js" result) :to-be-truthy)
+          ;; Should NOT match other extensions even in subdirectories.
+          (expect (assoc "main.py" result) :to-be nil)
+          (expect (assoc "src/helper.py" result) :to-be nil)
+          (expect (assoc "src/components/modal.ts" result) :to-be nil)))
+
+      (it "handles directory-specific regex patterns"
+        (let ((result
+               (macher--search-get-xref-matches context "hello" :file-regexp "^src/[^/]*\\.js$")))
+          ;; Should match .js files only in src/ directory (not subdirectories).
+          (expect (assoc "src/utils.js" result) :to-be-truthy)
+          ;; Should NOT match root level files.
+          (expect (assoc "app.js" result) :to-be nil)
+          ;; Should NOT match files in src/components/.
+          (expect (assoc "src/components/button.js" result) :to-be nil)
+          ;; Should NOT match other extensions in src/.
+          (expect (assoc "src/helper.py" result) :to-be nil)))
+
+      (it "handles regexp patterns relative to search directory when path is specified"
+        (let ((result
+               (macher--search-get-xref-matches
+                context
+                "hello"
+                :path "src"
+                :file-regexp "^[^/]*\\.js$")))
+          ;; When searching in "src" directory, regexp should be relative to "src". So
+          ;; "^[^/]*\\.js$" should match .js files directly in src/ (results show relative to workspace root).
+          (expect (assoc "src/utils.js" result) :to-be-truthy)
+          ;; Should NOT match files in subdirectories of src/.
+          (expect (assoc "src/components/button.js" result) :to-be nil)
+          ;; Should NOT match other extensions
+          (expect (assoc "src/helper.py" result) :to-be nil)
+          ;; Should NOT match files from other directories.
+          (expect (assoc "app.js" result) :to-be nil)))
+
+      (it "handles deeply nested directory regexp patterns (when no path specified)"
+        (let ((result
+               (macher--search-get-xref-matches context "hello" :file-regexp "^src/components/")))
+          ;; Should match all files in src/components/ (relative to workspace root).
+          (expect (assoc "src/components/button.js" result) :to-be-truthy)
+          (expect (assoc "src/components/modal.ts" result) :to-be-truthy)
+          ;; Should NOT match files in other directories.
+          (expect (assoc "app.js" result) :to-be nil)
+          (expect (assoc "src/utils.js" result) :to-be nil)))
+
+      (it "handles nested directory regexp patterns when searching within specific path"
+        (let ((result
+               (macher--search-get-xref-matches
+                context
+                "hello"
+                :path "src"
+                :file-regexp "^components/")))
+          ;; When searching in "src", regexp "^components/" should match files in src/components/.
+          ;; Results should be relative to workspace root.
+          (expect (assoc "src/components/button.js" result) :to-be-truthy)
+          (expect (assoc "src/components/modal.ts" result) :to-be-truthy)
+          ;; Should NOT match files directly in src/
+          (expect (assoc "src/utils.js" result) :to-be nil)
+          (expect (assoc "src/helper.py" result) :to-be nil)))
+
+      (it "handles recursive directory regexp patterns (when no path specified)"
+        (let ((result
+               (macher--search-get-xref-matches context "hello" :file-regexp "^src/.*\\.js$")))
+          ;; Should match .js files in src/ and all its subdirectories (relative to workspace root).
+          (expect (assoc "src/utils.js" result) :to-be-truthy)
+          (expect (assoc "src/components/button.js" result) :to-be-truthy)
+          ;; Should NOT match root level .js files.
+          (expect (assoc "app.js" result) :to-be nil)
+          ;; Should NOT match .js files in other top-level directories.
+          (expect (assoc "tests/app.test.js" result) :to-be nil)
+          ;; Should NOT match non-.js files even in src/ tree.
+          (expect (assoc "src/helper.py" result) :to-be nil)
+          (expect (assoc "src/components/modal.ts" result) :to-be nil)))
+
+      (it "handles recursive regexp patterns when searching within specific path"
+        (let ((result
+               (macher--search-get-xref-matches
+                context
+                "hello"
+                :path "src"
+                :file-regexp ".*\\.js$")))
+          ;; When searching in "src", regexp ".*\\.js$" should match all .js files in src/ tree.
+          ;; Results should be relative to workspace root.
+          (expect (assoc "src/utils.js" result) :to-be-truthy)
+          (expect (assoc "src/components/button.js" result) :to-be-truthy)
+          ;; Should NOT match non-.js files
+          (expect (assoc "src/helper.py" result) :to-be nil)
+          (expect (assoc "src/components/modal.ts" result) :to-be nil)
+          ;; Should NOT match files from other directories.
+          (expect (assoc "app.js" result) :to-be nil)
+          (expect (assoc "tests/app.test.js" result) :to-be nil)))
+
+      (it "handles multiple extension regexp patterns"
+        (let ((result
+               (macher--search-get-xref-matches
+                context
+                "hello"
+                :file-regexp "^[^/]*\\.\\(js\\|py\\)$")))
+          ;; Should match both .js and .py files at root level.
+          (expect (assoc "app.js" result) :to-be-truthy)
+          (expect (assoc "main.py" result) :to-be-truthy)
+          ;; Should NOT match other extensions.
+          (expect (assoc "README.txt" result) :to-be nil)
+          ;; Should NOT match files in subdirectories.
+          (expect (assoc "src/utils.js" result) :to-be nil)
+          (expect (assoc "src/helper.py" result) :to-be nil)))
+
+      (it "handles recursive multiple extension regexp patterns"
+        (let ((result
+               (macher--search-get-xref-matches context "hello" :file-regexp "\\.\\(js\\|ts\\)$")))
+          ;; Should match both .js and .ts files at all levels.
+          (expect (assoc "app.js" result) :to-be-truthy)
+          (expect (assoc "src/utils.js" result) :to-be-truthy)
+          (expect (assoc "src/components/button.js" result) :to-be-truthy)
+          (expect (assoc "tests/app.test.js" result) :to-be-truthy)
+          (expect (assoc "src/components/modal.ts" result) :to-be-truthy)
+          ;; Should NOT match .py files.
+          (expect (assoc "main.py" result) :to-be nil)
+          (expect (assoc "src/helper.py" result) :to-be nil)
+          (expect (assoc "tests/test_main.py" result) :to-be nil)))
+
+      (it "handles complex path patterns"
+        (let ((result
+               (macher--search-get-xref-matches context "hello" :file-regexp "^.*/test[^/]*$")))
+          ;; Should match files that start with 'test' anywhere in the tree.
+          (expect (assoc "tests/test_main.py" result) :to-be-truthy)
+          ;; Should NOT match files that just contain 'test' in the middle.
+          (expect (assoc "tests/app.test.js" result) :to-be nil)
+          ;; Should NOT match other files.
+          (expect (assoc "app.js" result) :to-be nil)))
+
+      (it "handles exact filename regexp patterns"
+        (let ((result
+               (macher--search-get-xref-matches context "hello" :file-regexp "button\\.js$")))
+          ;; Should match button.js anywhere in the tree (relative to workspace root).
+          (expect (assoc "src/components/button.js" result) :to-be-truthy)
+          ;; Should NOT match other .js files.
+          (expect (assoc "app.js" result) :to-be nil)
+          (expect (assoc "src/utils.js" result) :to-be nil)))
+
+      (it "handles exact filename regexp patterns when searching within specific path"
+        (let ((result
+               (macher--search-get-xref-matches
+                context
+                "hello"
+                :path "src/components"
+                :file-regexp "button\\.js$")))
+          ;; Should match button.js within the search path, result relative to workspace root.
+          (expect (assoc "src/components/button.js" result) :to-be-truthy)
+          ;; Should NOT match modal.ts.
+          (expect (assoc "src/components/modal.ts" result) :to-be nil)
+          ;; Should NOT show search-path-relative results.
+          (expect (assoc "button.js" result) :to-be nil)))
+
+      (it "handles no matches with restrictive regexp"
+        (let ((result (macher--search-get-xref-matches context "hello" :file-regexp "\\.xyz$")))
+          ;; Should match no files since no .xyz files exist.
+          (expect result :to-be nil)))
+
+      (it "combines path and regexp filtering with results relative to workspace root"
+        (let ((result
+               (macher--search-get-xref-matches context "hello" :path "src" :file-regexp "\\.py$")))
+          ;; Should match .py files in src/ directory, results relative to workspace root.
+          (expect (assoc "src/helper.py" result) :to-be-truthy)
+          ;; Should NOT match .py files in other directories (outside search path)...
+          ;; ...in root, outside "src" path
+          (expect (assoc "main.py" result) :to-be nil)
+          ;; ...n tests/, outside "src" path.
+          (expect (assoc "tests/test_main.py" result) :to-be nil)
+          ;; Should NOT match other extensions in src/.
+          (expect (assoc "src/utils.js" result) :to-be nil)
+          ;; Should NOT show search-path-relative results.
+          (expect (assoc "helper.py" result) :to-be nil)))
+
+      (it "handles regex with path limiting to subdirectory with results relative to workspace root"
+        (let ((result
+               (macher--search-get-xref-matches
+                context
+                "hello"
+                :path "src/components"
+                :file-regexp ".*")))
+          ;; Should match all files in src/components/, results relative to workspace root.
+          (expect (assoc "src/components/button.js" result) :to-be-truthy)
+          (expect (assoc "src/components/modal.ts" result) :to-be-truthy)
+          ;; Should NOT match files outside that specific directory.
+          (expect (assoc "src/utils.js" result) :to-be nil)
+          (expect (assoc "app.js" result) :to-be nil)
+          ;; Should NOT show search-path-relative results.
+          (expect (assoc "button.js" result) :to-be nil)
+          (expect (assoc "modal.ts" result) :to-be nil))))
+
+    ;; Advanced xref function tests - workspace boundary enforcement and complex scenarios.
+    (describe "boundary enforcement"
+      :var (context temp-dir extra-file)
+
+      (before-each
+        (setq temp-dir (make-temp-file "macher-test-boundary-dir" t))
+        (setq context
+              (macher--make-context :workspace (cons 'project (file-name-as-directory temp-dir))))
+        ;; Create project structure.
+        (write-region "hello world" nil (expand-file-name "included.txt" temp-dir))
+        (write-region "hello universe" nil (expand-file-name "also-included.js" temp-dir))
+        ;; Create an extra file that won't be in workspace-files list.
+        (setq extra-file (expand-file-name "excluded.txt" temp-dir))
+        (write-region "hello excluded" nil extra-file)
+        ;; Create project marker.
+        (write-region "" nil (expand-file-name ".project" temp-dir)))
+
+      (after-each
+        (when (and temp-dir (file-exists-p temp-dir))
+          (delete-directory temp-dir t)))
+
+      (it "excludes files not in workspace-files list"
+        ;; Mock workspace-files to exclude extra-file.
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace)
+           (let ((files (macher--project-files (cdr workspace))))
+             (cl-remove-if (lambda (file) (string-match-p "excluded\\.txt$" file)) files))))
+
+        (let ((result (macher--search-get-xref-matches context "hello")))
+          ;; Should find files that are in workspace-files.
+          (expect (assoc "included.txt" result) :to-be-truthy)
+          (expect (assoc "also-included.js" result) :to-be-truthy)
+          ;; Should NOT find files excluded from workspace-files, even if they exist and match.
+          (expect (assoc "excluded.txt" result) :to-be nil)))
+
+      (it "includes files from macher-context even if not in workspace-files"
+        ;; Mock workspace-files to exclude extra-file.
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace)
+           (let ((files (macher--project-files (cdr workspace))))
+             (cl-remove-if (lambda (file) (string-match-p "excluded\\.txt$" file)) files))))
+
+        ;; Add content to context for the excluded file.
+        (macher-context--set-new-content-for-file extra-file "hello from context" context)
+
+        (let ((result (macher--search-get-xref-matches context "hello")))
+          ;; Should find regular workspace files.
+          (expect (assoc "included.txt" result) :to-be-truthy)
+          ;; Should find files from context even if not in workspace-files.
+          (expect (assoc "excluded.txt" result) :to-be-truthy)
+          ;; Verify it searches the context content, not the file content.
+          (let ((matches (cdr (assoc "excluded.txt" result))))
+            ;; Extract summary from the first xref-match-item
+            (expect (xref-item-summary (car matches)) :to-equal "hello from context")))))
+
+    ;; Tests for projects under ~ using macher-context.
+    (describe "projects under tilde"
+      :var (context)
+
+      (before-each
+        ;; Create a mock workspace under ~ without creating actual files.
+        (let ((mock-workspace-root "~/test-project/"))
+          (setq context (macher--make-context :workspace (cons 'project mock-workspace-root)))
+
+          ;; Mock workspace-files to return fake file list.
+          (spy-on
+           'macher--workspace-files
+           :and-return-value
+           '("~/test-project/src/main.el"
+             "~/test-project/tests/test-main.el"
+             "~/test-project/README.md"))
+          ;; Mock workspace-root.
+          (spy-on 'macher--workspace-root :and-return-value mock-workspace-root)))
+
+      (it "handles tilde paths with context-only files"
+        ;; Add files to context (no actual filesystem files created).
+        (macher-context--set-new-content-for-file
+         "~/test-project/src/main.el"
+         "function hello() {\n  console.log('hello world');\n}"
+         context)
+        (macher-context--set-new-content-for-file
+         "~/test-project/tests/test-main.el"
+         "describe('hello function', () => {\n  it('should say hello', () => {\n    hello();\n  });\n});"
+         context)
+        (macher-context--set-new-content-for-file
+         "~/test-project/README.md"
+         "# Test Project\n\nThis is a test project with hello functionality."
+         context)
+
+        (let ((result (macher--search-get-xref-matches context "hello")))
+          ;; Should find matches in all files under ~.
+          (expect (assoc "src/main.el" result) :to-be-truthy)
+          (expect (assoc "tests/test-main.el" result) :to-be-truthy)
+          (expect (assoc "README.md" result) :to-be-truthy)
+
+          ;; Verify content is from context - check first line which should contain "function
+          ;; hello".
+          (let ((main-matches (cdr (assoc "src/main.el" result))))
+            ;; Extract summary from the first xref-match-item.
+            (expect (xref-item-summary (car main-matches)) :to-match "hello"))))
+
+      (it "applies regexp filtering with tilde paths"
+        ;; Add same files to context.
+        (macher-context--set-new-content-for-file
+         "~/test-project/src/main.el" "hello world" context)
+        (macher-context--set-new-content-for-file
+         "~/test-project/tests/test-main.el" "hello test" context)
+        (macher-context--set-new-content-for-file "~/test-project/README.md" "hello readme" context)
+
+        ;; Test filtering to only .el files.
+        (let ((result (macher--search-get-xref-matches context "hello" :file-regexp "\\.el$")))
+          (expect (assoc "src/main.el" result) :to-be-truthy)
+          (expect (assoc "tests/test-main.el" result) :to-be-truthy)
+          (expect (assoc "README.md" result) :to-be nil)))
+
+      (it "handles regexp patterns starting with ^ for tilde paths"
+        ;; Add files to context with specific directory structure.
+        (macher-context--set-new-content-for-file
+         "~/test-project/src/main.js" "function main() { console.log('main function'); }" context)
+        (macher-context--set-new-content-for-file
+         "~/test-project/src/other.js"
+         "function other() { console.log('other function'); }"
+         context)
+        (macher-context--set-new-content-for-file
+         "~/test-project/lib/main.js" "function lib() { console.log('lib function'); }" context)
+        (macher-context--set-new-content-for-file
+         "~/test-project/tests/main.test.js"
+         "test('main', () => { expect(main()).toBeTruthy(); });"
+         context)
+
+        ;; Mock workspace-files to include these files.
+        (spy-on
+         'macher--workspace-files
+         :and-return-value
+         '("~/test-project/src/main.js"
+           "~/test-project/src/other.js"
+           "~/test-project/lib/main.js"
+           "~/test-project/tests/main.test.js"))
+
+        ;; Test pattern that should only match files starting with "src/" (relative to workspace root).
+        (let ((result (macher--search-get-xref-matches context "main" :file-regexp "^src/")))
+          ;; Should match only the file in src/ directory (relative to workspace root).
+          (expect (assoc "src/main.js" result) :to-be-truthy)
+          ;; Should NOT match files in other directories.
+          (expect (assoc "lib/main.js" result) :to-be nil)
+          (expect (assoc "src/other.js" result) :to-be nil)
+          (expect (assoc "tests/main.test.js" result) :to-be nil)))
+
+      (it "handles regexp patterns starting with ^ when searching within specific path"
+        ;; Add files to context
+        (macher-context--set-new-content-for-file
+         "~/test-project/src/main.js" "function main() { console.log('main function'); }" context)
+        (macher-context--set-new-content-for-file
+         "~/test-project/src/components/button.js" "component main button" context)
+        (macher-context--set-new-content-for-file
+         "~/test-project/src/utils/main.js" "utility main functions" context)
+
+        ;; Mock workspace-files.
+        (spy-on
+         'macher--workspace-files
+         :and-return-value
+         '("~/test-project/src/main.js"
+           "~/test-project/src/components/button.js"
+           "~/test-project/src/utils/main.js"))
+
+        ;; Test pattern when searching within "src" directory.
+        (let ((result
+               (macher--search-get-xref-matches
+                context
+                "main"
+                :path "src"
+                :file-regexp "^[^/]*\\.js$")))
+          ;; Should match only files directly in src/ (not in subdirectories), relative to workspace root.
+          (expect (assoc "src/main.js" result) :to-be-truthy)
+          ;; Should NOT match files in subdirectories.
+          (expect (assoc "src/components/button.js" result) :to-be nil)
+          (expect (assoc "src/utils/main.js" result) :to-be nil)
+          ;; Should NOT show search-path-relative results.
+          (expect (assoc "main.js" result) :to-be nil)))))
+
+  (describe "buffer management"
+    :var (context temp-dir)
+
+    (before-each
+      (setq temp-dir (make-temp-file "macher-test-buffer-mgmt" t))
+      (setq context
+            (macher--make-context :workspace (cons 'project (file-name-as-directory temp-dir))))
+      ;; Create test files that are not currently loaded in buffers.
+      (write-region "hello world\ntest content" nil (expand-file-name "test1.txt" temp-dir))
+      (write-region "hello universe\nmore content" nil (expand-file-name "test2.txt" temp-dir))
+      ;; Add the project marker.
+      (write-region "" nil (expand-file-name ".project" temp-dir)))
+
+    (after-each
+      (when (and temp-dir (file-exists-p temp-dir))
+        (delete-directory temp-dir t)))
+
+    (it "does not create any new buffers when searching"
+      (let ((buffer-names-before (mapcar #'buffer-name (buffer-list))))
+
+        ;; Perform search that should find matches in files not loaded as buffers.
+        (let ((result (macher--search-get-xref-matches context "hello")))
+          ;; Verify we found matches.
+          (expect (length result) :to-be 2)
+          (expect (assoc "test1.txt" result) :to-be-truthy)
+          (expect (assoc "test2.txt" result) :to-be-truthy)
+
+          (let ((buffer-names-after (mapcar #'buffer-name (buffer-list))))
+            (expect buffer-names-after :to-equal buffer-names-before)))))
+
+    (it "loads matched files into macher-context"
+      ;; Create test files that are NOT already in the context.
+      ;; These files contain "hello" and should be matched and loaded.
+      (write-region "hello world\ntest content" nil (expand-file-name "context-test1.txt" temp-dir))
+      (write-region
+       "hello universe\nmore content" nil (expand-file-name "context-test2.txt" temp-dir))
+      ;; Create files that do NOT match the search pattern and should NOT be loaded.
+      (write-region
+       "goodbye world\nno matches here" nil (expand-file-name "no-match1.txt" temp-dir))
+      (write-region
+       "farewell universe\nnothing to find" nil (expand-file-name "no-match2.txt" temp-dir))
+      ;; Add the project marker.
+      (write-region "" nil (expand-file-name ".project" temp-dir))
+
+      ;; Verify files are NOT already loaded in context.
+      (let ((context-files-before (mapcar #'car (macher-context-contents context))))
+        ;; Matching files should not be in context yet.
+        (expect
+         (member (expand-file-name "context-test1.txt" temp-dir) context-files-before)
+         :to-be nil)
+        (expect
+         (member (expand-file-name "context-test2.txt" temp-dir) context-files-before)
+         :to-be nil)
+        ;; Non-matching files should not be in context yet.
+        (expect
+         (member (expand-file-name "no-match1.txt" temp-dir) context-files-before)
+         :to-be nil)
+        (expect
+         (member (expand-file-name "no-match2.txt" temp-dir) context-files-before)
+         :to-be nil)
+
+        ;; Perform search that should find matches and load files into context.
+        (let ((result (macher--search-get-xref-matches context "hello")))
+          ;; Verify we found matches only in files that contain "hello".
+          (expect (assoc "context-test1.txt" result) :to-be-truthy)
+          (expect (assoc "context-test2.txt" result) :to-be-truthy)
+          ;; Verify no matches were found in files that don't contain "hello".
+          (expect (assoc "no-match1.txt" result) :to-be nil)
+          (expect (assoc "no-match2.txt" result) :to-be nil)
+
+          ;; Verify matched files are now loaded in context, but non-matching files are NOT.
+          (let ((context-files-after (mapcar #'car (macher-context-contents context))))
+            ;; Files with matches should now be loaded in context.
+            (expect
+             (member (expand-file-name "context-test1.txt" temp-dir) context-files-after)
+             :to-be-truthy)
+            (expect
+             (member (expand-file-name "context-test2.txt" temp-dir) context-files-after)
+             :to-be-truthy)
+            ;; Files without matches should NOT be loaded in context.
+            (expect
+             (member (expand-file-name "no-match1.txt" temp-dir) context-files-after)
+             :to-be nil)
+            (expect
+             (member (expand-file-name "no-match2.txt" temp-dir) context-files-after)
+             :to-be nil)
+
+            ;; Verify content was loaded correctly (without creating buffers).
+            (let* ((file1-path (expand-file-name "context-test1.txt" temp-dir))
+                   (file1-contents (macher-context--contents-for-file file1-path context))
+                   (file2-path (expand-file-name "context-test2.txt" temp-dir))
+                   (file2-contents (macher-context--contents-for-file file2-path context)))
+              ;; Check that content matches what we wrote to disk.
+              (expect (cdr file1-contents) :to-equal "hello world\ntest content")
+              (expect (cdr file2-contents) :to-equal "hello universe\nmore content")))))))
+
+
+  (describe "macher--search-format-files-mode"
+    :var (context temp-dir)
+
+    (before-each
+      (setq temp-dir (make-temp-file "macher-test-files-mode" t))
+      (setq context
+            (macher--make-context :workspace (cons 'project (file-name-as-directory temp-dir))))
+      (write-region "hello world\nhello universe" nil (expand-file-name "file1.txt" temp-dir))
+      (write-region "hello javascript" nil (expand-file-name "file2.js" temp-dir))
+      ;; Add the project marker.
+      (write-region "" nil (expand-file-name ".project" temp-dir)))
+
+    (after-each
+      (when (and temp-dir (file-exists-p temp-dir))
+        (delete-directory temp-dir t)))
+
+    (it "formats files mode output correctly"
+      (let* ((matches-alist (macher--search-get-xref-matches context "hello"))
+             (result (macher--search-format-files-mode matches-alist)))
+        (expect
+         result
+         :to-equal
+         (concat
+          "file1.txt (2 matches)\n" "file2.js (1 match)\n" "\n" "Total: 3 matches in 2 files"))))
+
+    (it "handles empty matches alist"
+      (let ((result (macher--search-format-files-mode '())))
+        (expect result :to-equal "")))
+
+    (it "uses correct singular/plural forms"
+      (let* ((matches-alist (macher--search-get-xref-matches context "javascript"))
+             (result (macher--search-format-files-mode matches-alist)))
+        (expect result :to-match "1 match")
+        (expect result :to-match "1 file"))))
+
+  (describe "macher--search-format-content-mode"
+    :var (context temp-dir)
+
+    (before-each
+      (setq temp-dir (make-temp-file "macher-test-content-dir" t))
+      (setq context
+            (macher--make-context :workspace (cons 'project (file-name-as-directory temp-dir))))
+      (write-region
+       "line1\nhello world\nhello universe\nline4" nil (expand-file-name "test.txt" temp-dir))
+      ;; Add the project marker.
+      (write-region "" nil (expand-file-name ".project" temp-dir)))
+
+    (after-each
+      (when (and temp-dir (file-exists-p temp-dir))
+        (delete-directory temp-dir t)))
+
+    (it "formats content mode output without line numbers"
+      (let* ((matches-alist (macher--search-get-xref-matches context "hello"))
+             (result (macher--search-format-content-mode context matches-alist nil nil nil)))
+        ;; Verify exact output structure: filename:matched_line for each match, separated by newlines.
+        (expect result :to-equal (concat "test.txt:hello world\n" "test.txt:hello universe\n"))))
+
+    (it "formats content mode output with line numbers"
+      (let* ((matches-alist (macher--search-get-xref-matches context "hello"))
+             (result (macher--search-format-content-mode context matches-alist nil nil t)))
+        ;; Verify exact output with line numbers: filename:line_number:matched_line.
+        (expect
+         result
+         :to-equal (concat "test.txt:2:hello world\n" "test.txt:3:hello universe\n"))))
+
+    (it "includes context lines when specified"
+      (let* ((matches-alist (macher--search-get-xref-matches context "hello world"))
+             (result (macher--search-format-content-mode context matches-alist 1 1 nil)))
+        ;; Verify exact output with context: before lines use '-', match lines use ':', after lines use '-'.
+        (expect
+         result
+         :to-equal (concat "test.txt-line1\n" "test.txt:hello world\n" "test.txt-hello universe\n"))))
+
+    (it "merges overlapping context ranges"
+      (let* ((matches-alist (macher--search-get-xref-matches context "hello"))
+             (result (macher--search-format-content-mode context matches-alist 1 1 nil)))
+        ;; Verify exact merged output: overlapping context should be merged into one continuous block.
+        ;; Line 1 (before first match), Line 2 (first match), Line 3 (second match), Line 4 (after second match).
+        ;; No separators (--) should appear since the context ranges overlap and merge.
+        (expect
+         result
+         :to-equal
+         (concat
+          "test.txt-line1\n"
+          "test.txt:hello world\n"
+          "test.txt:hello universe\n"
+          "test.txt-line4\n"))))
+
+    (it "separates non-overlapping context ranges"
+      ;; Create a file with widely separated matches to test separator behavior.
+      (write-region
+       "line1\nhello first\nline3\nline4\nline5\nline6\nhello second\nline8"
+       nil
+       (expand-file-name "separate.txt" temp-dir))
+
+      (let* ((matches-alist (macher--search-get-xref-matches context "hello"))
+             ;; Get just the matches from separate.txt.
+             (separate-matches (assoc "separate.txt" matches-alist))
+             (result (macher--search-format-content-mode context (list separate-matches) 1 1 nil)))
+        ;; Verify output has separator (--) between non-overlapping context ranges.
+        ;; Range 1: line1, hello first, line3
+        ;; Range 2: line6, hello second, line8
+        (expect
+         result
+         :to-equal
+         (concat
+          "separate.txt-line1\n"
+          "separate.txt:hello first\n"
+          "separate.txt-line3\n"
+          "--\n"
+          "separate.txt-line6\n"
+          "separate.txt:hello second\n"
+          "separate.txt-line8\n"))))
+
+    (it "handles large files and complex match patterns"
+      ;; Create a large file with multiple overlapping and non-overlapping match ranges.
+      (let ((large-content
+             (concat
+              "line1\n"
+              "function test() {\n"
+              "  console.log('hello world');\n"
+              "  console.log('hello universe');\n"
+              "}\n"
+              "line6\n"
+              "line7\n"
+              "line8\n"
+              "line9\n"
+              "line10\n"
+              "function other() {\n"
+              "  console.log('hello there');\n"
+              "line13\n"
+              "  console.log('hello again');\n"
+              "}\n"
+              "line16\n"
+              "line17\n"
+              "line18\n"
+              "line19\n"
+              "line20\n"
+              "function final() {\n"
+              "  console.log('hello final');\n"
+              "}\n"
+              "line24\n")))
+        (write-region large-content nil (expand-file-name "large.js" temp-dir))
+
+        (let* ((matches-alist (macher--search-get-xref-matches context "hello"))
+               ;; Get just the matches from large.js.
+               (large-matches (assoc "large.js" matches-alist))
+               (result (macher--search-format-content-mode context (list large-matches) 2 2 nil)))
+          ;; Verify output structure:
+          ;; First range (overlapping): lines 1-6 covering first two hello matches
+          ;; Second range (overlapping): lines 10-15 covering next two hello matches
+          ;; Third range (non-overlapping): lines 20-24 covering final hello match
+          (expect
+           result
+           :to-equal
+           (concat
+            "large.js-line1\n"
+            "large.js-function test() {\n"
+            "large.js:  console.log('hello world');\n"
+            "large.js:  console.log('hello universe');\n"
+            "large.js-}\n"
+            "large.js-line6\n"
+            "--\n"
+            "large.js-line10\n"
+            "large.js-function other() {\n"
+            "large.js:  console.log('hello there');\n"
+            "large.js-line13\n"
+            "large.js:  console.log('hello again');\n"
+            "large.js-}\n"
+            "large.js-line16\n"
+            "--\n"
+            "large.js-line20\n"
+            "large.js-function final() {\n"
+            "large.js:  console.log('hello final');\n"
+            "large.js-}\n"
+            "large.js-line24\n"))))))
+
+  (describe "macher--tool-search-helper"
+    :var (context temp-dir)
+
+    (before-each
+      (setq temp-dir (make-temp-file "macher-test-search-dir" t))
+      (setq context
+            (macher--make-context :workspace (cons 'project (file-name-as-directory temp-dir))))
+      ;; Create test directory structure.
+      (make-directory (expand-file-name "subdir" temp-dir))
+      (write-region
+       "hello world\nhello universe\ngoodbye world" nil (expand-file-name "file1.txt" temp-dir))
+      (write-region
+       "hello javascript\nfunction test() {}\nconst x = 1;"
+       nil
+       (expand-file-name "file2.js" temp-dir))
+      (write-region
+       "hello python\ndef test():\n    pass" nil (expand-file-name "subdir/file3.py" temp-dir))
+      (write-region "no matches here\nnothing to find" nil (expand-file-name "file4.txt" temp-dir))
+      ;; Add the project marker.
+      (write-region "" nil (expand-file-name ".project" temp-dir)))
+
+    (after-each
+      (when (and temp-dir (file-exists-p temp-dir))
+        (delete-directory temp-dir t)))
+
+    (it "handles basic search functionality"
+      (let ((result (macher--tool-search-helper context "hello")))
+        ;; Verify exact files mode output structure with correct counts and totals.
+        (expect
+         result
+         :to-equal
+         (concat
+          "file1.txt (2 matches)\n"
+          "file2.js (1 match)\n"
+          "subdir/file3.py (1 match)\n"
+          "\n"
+          "Total: 4 matches in 3 files"))))
+
+    (it "handles content mode"
+      (let ((result (macher--tool-search-helper context "hello" :mode "content")))
+        ;; Verify exact content mode output with all matching lines from all files.
+        (expect
+         result
+         :to-equal
+         (concat
+          "file1.txt:hello world\n"
+          "file1.txt:hello universe\n"
+          "file2.js:hello javascript\n"
+          "subdir/file3.py:hello python\n"))))
+
+    (it "applies head-limit correctly"
+      (let ((result (macher--tool-search-helper context "hello" :head-limit 2)))
+        ;; Verify exact head-limited output: only first 2 lines from files mode.
+        (expect result :to-equal (concat "file1.txt (2 matches)\n" "file2.js (1 match)"))))
+
+    (it "handles content mode with context lines"
+      (let ((result
+             (macher--tool-search-helper
+              context
+              "hello world"
+              :mode "content"
+              :lines-before 1
+              :lines-after 1)))
+        ;; Verify exact content output with context lines for specific pattern match. "hello world"
+        ;; is on line 1, so no line before, "hello universe" is line after.
+        (expect result :to-equal (concat "file1.txt:hello world\n" "file1.txt-hello universe\n"))))
+
+    (it "handles specific pattern matching"
+      (let ((result (macher--tool-search-helper context "javascript")))
+        ;; Verify exact output for pattern that matches only one file.
+        (expect result :to-equal (concat "file2.js (1 match)\n" "\n" "Total: 1 match in 1 file"))))
+
+    (it "validates parameters correctly"
+      (expect (macher--tool-search-helper context "hello" :mode "invalid") :to-throw)
+      (expect (macher--tool-search-helper context "") :to-throw))
+
+    (it "shows exact path when searching specific file"
+      ;; When path points to a specific file rather than directory, results should show exact path.
+      (let ((result (macher--tool-search-helper context "hello" :path "file1.txt")))
+        (expect result :to-match "file1.txt (2 matches)")
+        (expect result :not :to-match "subdir/")
+        (expect result :not :to-match "file2.js")))
+
+    (describe "error handling"
+      :var
+      (context workspace temp-file)
+      (before-each
+        (funcall setup-project)
+        ;; Create workspace and context.
+        (setq workspace `(project . ,project-dir))
+        (setq context (macher--make-context :workspace workspace))
+        ;; Create a test file with content that includes parentheses.
+        (setq temp-file (expand-file-name "test-search.el" project-dir))
+        (with-temp-buffer
+          (insert "(describe \"search_in_workspace\"\n")
+          (insert "  (it \"test case\"\n")
+          (insert "    (expect true :to-be-truthy)))\n")
+          (write-region (point-min) (point-max) temp-file)))
+
+      (it "handles invalid regex patterns in search"
+        ;; Test pattern with unmatched opening parenthesis - this should trigger regex parse error.
+        (expect
+         (macher--tool-search context "\\(describe \"search_in_workspace\"")
+         :to-throw 'user-error)))
+
+    (describe "comprehensive tests"
+      :var (context temp-dir)
+
+      (before-each
+        (setq temp-dir (make-temp-file "macher-test-helper-dir" t))
+        (setq context
+              (macher--make-context :workspace (cons 'project (file-name-as-directory temp-dir))))
+        ;; Create comprehensive test structure.
+        (make-directory (expand-file-name "src" temp-dir))
+        (make-directory (expand-file-name "tests" temp-dir))
+        (make-directory (expand-file-name "docs" temp-dir))
+
+        ;; Create files with varied content.
+        (write-region
+         "function processUser(user) {\n  console.log('Processing user:', user.name);\n  return user;\n}"
+         nil
+         (expand-file-name "src/user.js" temp-dir))
+        (write-region
+         "def process_user(user):\n    print(f'Processing user: {user.name}')\n    return user"
+         nil
+         (expand-file-name "src/user.py" temp-dir))
+        (write-region
+         "describe('processUser', () => {\n  it('should process user correctly', () => {});\n});"
+         nil
+         (expand-file-name "tests/user.test.js" temp-dir))
+        (write-region
+         "# User Processing\n\nThis module processes user data efficiently."
+         nil
+         (expand-file-name "docs/user.md" temp-dir))
+
+        ;; Add project marker.
+        (write-region "" nil (expand-file-name ".project" temp-dir)))
+
+      (after-each
+        (when (and temp-dir (file-exists-p temp-dir))
+          (delete-directory temp-dir t)))
+
+      (it "handles complex regexp patterns with context and path filters"
+        ;; Add additional content to context.
+        (macher-context--set-new-content-for-file
+         (expand-file-name "src/new-feature.js" temp-dir)
+         "// New feature for processing user requests\nfunction processUserRequest() {}"
+         context)
+
+        ;; Search for "process" in src directory, JS files only.
+        (let ((result
+               (macher--tool-search-helper context "process" :path "src" :file-regexp "\\.js$")))
+          ;; Should find matches in JS files in src/, results relative to workspace root (like
+          ;; grep).
+          (expect result :to-match "src/user.js")
+          (expect result :to-match "src/new-feature.js")
+          ;; Should NOT find matches in Python files or other directories.
+          (expect result :not :to-match "user.py")
+          (expect result :not :to-match "tests/")
+          (expect result :not :to-match "docs/")
+          ;; Should NOT show paths relative to the search root.
+          (expect result :not :to-match "^user.js")
+          (expect result :not :to-match "^new-feature.js")))
+
+      (it "handles complex patterns in context files"
+        ;; Add content to context
+        (macher-context--set-new-content-for-file
+         (expand-file-name "src/config.js" temp-dir)
+         "const config = {\n  user: {\n    processing: true\n  }\n};"
+         context)
+
+        ;; Search for pattern that spans multiple words
+        (let ((result (macher--tool-search-helper context "processing")))
+          (expect result :to-match "src/config.js")))
+
+      (it "respects head-limit with mixed content sources"
+        ;; Add several context files
+        (dotimes (i 5)
+          (macher-context--set-new-content-for-file
+           (expand-file-name (format "context-file-%d.txt" i) temp-dir)
+           "This file contains the word target for searching"
+           context))
+
+        ;; Search with head-limit
+        (let ((result (macher--tool-search-helper context "target" :head-limit 3)))
+          ;; Count lines in result - should be 3 or fewer
+          (let ((lines (split-string result "\n" t)))
+            (expect (<= (length lines) 3) :to-be-truthy))))
+
+      (it "combines multiple filters effectively"
+        ;; Add specific test content.
+        (macher-context--set-new-content-for-file
+         (expand-file-name "tests/integration.test.js" temp-dir)
+         "describe('Integration tests', () => {\n expect(true).toBe(true);\n});"
+         context)
+
+        (let ((result
+               (macher--tool-search-helper
+                context
+                "test"
+                :path "tests"
+                :file-regexp "\\.js$"
+                :show-line-numbers t)))
+          ;; Should match files in tests directory that contain "test" in content, results relative
+          ;; to workspace root (like grep).
+          (expect result :to-match "tests/integration.test.js")
+          (expect result :to-match "test")
+          ;; Should NOT match files that don't contain the pattern in content.
+          (expect result :not :to-match "tests/user.test.js")
+          ;; Should NOT show relative paths.
+          (expect result :not :to-match "^integration.test.js")
+          (expect result :not :to-match "^user.test.js")))
+
+      (it "handles projects under tilde with context files"
+        ;; Create mock tilde workspace
+        (let ((tilde-context (macher--make-context :workspace '(project . "~/my-project/"))))
+          ;; Mock workspace functions
+          (spy-on
+           'macher--workspace-files
+           :and-return-value '("~/my-project/main.py" "~/my-project/test.py"))
+          (spy-on 'macher--workspace-root :and-return-value "~/my-project/")
+
+          ;; Add context files
+          (macher-context--set-new-content-for-file
+           "~/my-project/main.py"
+           "def main():\n    print('Hello from main')\n    return 0"
+           tilde-context)
+          (macher-context--set-new-content-for-file
+           "~/my-project/test.py"
+           "import unittest\nclass TestMain(unittest.TestCase):\n    def test_main(self): pass"
+           tilde-context)
+
+          (let ((result (macher--tool-search-helper tilde-context "main" :file-regexp "\\.py$")))
+            ;; Should find matches in tilde-based project (relative to workspace root).
+            (expect result :to-match "main.py")
+            (expect result :to-match "test.py"))))
+
+      (it "handles case-insensitive search"
+        ;; Add files with mixed case content.
+        (macher-context--set-new-content-for-file
+         (expand-file-name "mixed-case.txt" temp-dir)
+         "Hello World\nthis is HELLO again\nGoodbye"
+         context)
+        (macher-context--set-new-content-for-file
+         (expand-file-name "lower-case.txt" temp-dir) "hello universe\nbye" context)
+
+        ;; Case-sensitive search (default) should only find lowercase 'hello'
+        (let ((result (macher--tool-search-helper context "hello")))
+          (expect result :to-match "lower-case.txt")
+          (expect result :not :to-match "mixed-case.txt"))
+
+        ;; Case-insensitive search should find both
+        (let ((result (macher--tool-search-helper context "hello" :case-insensitive t)))
+          (expect result :to-match "lower-case.txt")
+          (expect result :to-match "mixed-case.txt")))
+
+      (it "shows exact path when searching specific file rather than directory"
+        ;; Add content to a specific file.
+        (macher-context--set-new-content-for-file
+         (expand-file-name "src/user.js" temp-dir)
+         "function processUser(user) {\n  console.log('Processing user:', user.name);\n  return user;\n}"
+         context)
+
+        ;; When searching a specific file, results should show the exact path provided.
+        (let ((result (macher--tool-search-helper context "process" :path "src/user.js")))
+          ;; Should show the exact file path as provided, not relative to anything.
+          (expect result :to-match "src/user.js")
+          ;; Should NOT show just the filename.
+          (expect result :not :to-match "^user.js"))))
+
+    (describe "float input handling"
+      (it "handles float inputs for lines-after parameter"
+        ;; Float should be rounded to nearest integer. Must use content mode for context lines.
+        (let ((result-2.3
+               (macher--tool-search-helper context "hello" :mode "content" :lines-after 2.3))
+              (result-2.7
+               (macher--tool-search-helper context "hello" :mode "content" :lines-after 2.7)))
+          ;; 2.3 should round to 2 lines after.
+          (expect result-2.3 :to-match "hello world")
+          (expect result-2.3 :to-match "hello universe")
+          ;; 2.7 should round to 3 lines after.
+          (expect result-2.7 :to-match "hello world")
+          (expect result-2.7 :to-match "hello universe")
+          (expect result-2.7 :to-match "goodbye world")))
+
+      (it "handles float inputs for lines-before parameter"
+        ;; Test lines-before with float inputs. Must use content mode for context lines.
+        (let ((result-1.4
+               (macher--tool-search-helper context "universe" :mode "content" :lines-before 1.4))
+              (result-1.6
+               (macher--tool-search-helper context "universe" :mode "content" :lines-before 1.6)))
+          ;; 1.4 should round to 1 line before.
+          (expect result-1.4 :to-match "hello world")
+          (expect result-1.4 :to-match "hello universe")
+          ;; 1.6 should round to 2 lines before - but there's only 1 line before "universe".
+          (expect result-1.6 :to-match "hello world")
+          (expect result-1.6 :to-match "hello universe")))
+
+      (it "handles float inputs for head-limit parameter"
+        ;; head-limit should limit the number of matches shown.
+        (let ((result-1.3 (macher--tool-search-helper context "hello" :head-limit 1.3))
+              (result-2.7 (macher--tool-search-helper context "hello" :head-limit 2.7)))
+          ;; 1.3 should round to 1, showing only the first match.
+          (expect (length (split-string result-1.3 "\n" t)) :to-be-less-than 5)
+          ;; 2.7 should round to 3, showing up to 3 matches.
+          (expect (length (split-string result-2.7 "\n" t)) :to-be-less-than 8)))
+
+      (it "handles edge case float inputs"
+        ;; Test with 0.x values and negative floats. Must use content mode for context lines.
+        (let ((result-0.4
+               (macher--tool-search-helper context "hello" :mode "content" :lines-after 0.4))
+              (result-0.6
+               (macher--tool-search-helper context "hello" :mode "content" :lines-after 0.6)))
+          ;; 0.4 should round to 0 (no extra lines).
+          (expect result-0.4 :to-match "hello")
+          ;; 0.6 should round to 1 (1 extra line).
+          (expect result-0.6 :to-match "hello")))))
+
+  (describe "macher--tool-read-file"
+    :var (context temp-dir)
+
+    (before-each
+      (setq temp-dir (make-temp-file "macher-test-dir" t))
+      (setq context (macher--make-context :workspace (cons 'project temp-dir)))
+      ;; Create test files.
+      (write-region "test file content" nil (expand-file-name "test-file.txt" temp-dir))
+
+      ;; Add the project marker.
+      (write-region "" nil (expand-file-name ".project" temp-dir)))
+
+    (after-each
+      (when (and temp-dir (file-exists-p temp-dir))
+        (delete-directory temp-dir t)))
+
+    (it "reads regular file content"
+      (let ((result (macher--tool-read-file context "test-file.txt")))
+        (expect result :to-equal "test file content")))
+
+    ;; TODO: We can't use multiple spies.
+    (it "returns symlink target for symlinks instead of following them"
+      ;; Create a symlink to the test file.
+      (let ((symlink-path (expand-file-name "test-symlink" temp-dir))
+            (target-path (expand-file-name "test-file.txt" temp-dir)))
+        (make-symbolic-link target-path symlink-path)
+
+        ;; Mock workspace files to include the symlink
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace) (append (macher--project-files (cdr workspace)) (list symlink-path))))
+
+        (let ((result (macher--tool-read-file context "test-symlink")))
+          (expect result :to-match "Symlink target:")
+          (expect result :to-match target-path))
+
+        ;; Clean up.
+        (delete-file symlink-path))
+
+      ;; Create a broken symlink.
+      (let ((broken-symlink-path (expand-file-name "broken-symlink" temp-dir)))
+        (make-symbolic-link "/nonexistent/target" broken-symlink-path)
+
+        ;; Mock workspace files to include the broken symlink
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace)
+           (append (macher--project-files (cdr workspace)) (list broken-symlink-path))))
+
+        (let ((result (macher--tool-read-file context "broken-symlink")))
+          (expect result :to-match "Symlink target:")
+          (expect result :to-match "/nonexistent/target"))
+
+        ;; Clean up.
+        (delete-file broken-symlink-path))
+
+      ;; Create a relative symlink.
+      (let ((rel-symlink-path (expand-file-name "rel-symlink" temp-dir)))
+        (make-symbolic-link "./test-file.txt" rel-symlink-path)
+
+        ;; Mock workspace files to include the relative symlink
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace)
+           (append (macher--project-files (cdr workspace)) (list rel-symlink-path))))
+
+        (let ((result (macher--tool-read-file context "rel-symlink")))
+          (expect result :to-match "Symlink target:")
+          (expect result :to-match "./test-file.txt"))
+
+        ;; Clean up.
+        (delete-file rel-symlink-path)))
+
+    (it "signals error for non-existent files"
+      (expect (macher--tool-read-file context "nonexistent.txt") :to-throw))
+
+    (describe "float parameter handling"
+      (it "handles float offset values by rounding them"
+        ;; Create test file for this test
+        (write-region "line1\nline2\nline3\nline4" nil (expand-file-name "multiline.txt" temp-dir))
+        ;; 1.0 should round to 1.
+        (expect
+         (macher--tool-read-file context "multiline.txt" 1.0)
+         :to-equal "line1\nline2\nline3\nline4")
+        ;; 2.3 should round to 2.
+        (expect
+         (macher--tool-read-file context "multiline.txt" 2.3)
+         :to-equal "line2\nline3\nline4")
+        ;; 2.7 should round to 3.
+        (expect (macher--tool-read-file context "multiline.txt" 2.7) :to-equal "line3\nline4")
+        ;; 40.0 should round to 40 (beyond bounds).
+        (expect (macher--tool-read-file context "multiline.txt" 40.0) :to-equal ""))
+
+      (it "handles float limit values by rounding them"
+        ;; Create test file for this test
+        (write-region "line1\nline2\nline3\nline4" nil (expand-file-name "multiline.txt" temp-dir))
+        ;; 1.0 should round to 1.
+        (expect (macher--tool-read-file context "multiline.txt" nil 1.0) :to-equal "line1")
+        ;; 2.3 should round to 2.
+        (expect (macher--tool-read-file context "multiline.txt" nil 2.3) :to-equal "line1\nline2")
+        ;; 2.7 should round to 3.
+        (expect
+         (macher--tool-read-file context "multiline.txt" nil 2.7)
+         :to-equal "line1\nline2\nline3")
+        ;; 40.0 should round to 40 (beyond bounds, return all).
+        (expect
+         (macher--tool-read-file context "multiline.txt" nil 40.0)
+         :to-equal "line1\nline2\nline3\nline4"))
+
+      (it "handles negative float values by rounding them"
+        ;; Create test file for this test
+        (write-region "line1\nline2\nline3\nline4" nil (expand-file-name "multiline.txt" temp-dir))
+        ;; -1.0 should round to -1.
+        (expect (macher--tool-read-file context "multiline.txt" -1.0) :to-equal "line4")
+        ;; -2.3 should round to -2.
+        (expect (macher--tool-read-file context "multiline.txt" -2.3) :to-equal "line3\nline4")
+        ;; -2.7 should round to -3.
+        (expect
+         (macher--tool-read-file context "multiline.txt" -2.7)
+         :to-equal "line2\nline3\nline4")
+        ;; -1.0 limit should round to -1 (4 - 1 = 3 lines).
+        (expect
+         (macher--tool-read-file context "multiline.txt" nil -1.0)
+         :to-equal "line1\nline2\nline3")
+        ;; -2.3 limit should round to -2 (4 - 2 = 2 lines).
+        (expect (macher--tool-read-file context "multiline.txt" nil -2.3) :to-equal "line1\nline2")
+        ;; -2.7 limit should round to -3 (4 - 3 = 1 line).
+        (expect (macher--tool-read-file context "multiline.txt" nil -2.7) :to-equal "line1"))
+
+      (it "handles both float offset and limit together"
+        ;; Create a 5-line file for this test
+        (write-region
+         "line1\nline2\nline3\nline4\nline5" nil (expand-file-name "fiveline.txt" temp-dir))
+        ;; 2.4 should round to 2, 2.6 should round to 3.
+        (expect
+         (macher--tool-read-file context "fiveline.txt" 2.4 2.6)
+         :to-equal "line2\nline3\nline4")
+        ;; 1.5 should round to 2, 1.4 should round to 1.
+        (expect (macher--tool-read-file context "fiveline.txt" 1.5 1.4) :to-equal "line2")
+        ;; Mix positive and negative floats: -2.3 should round to -2, 2.7 should round to 3.
+        (expect (macher--tool-read-file context "fiveline.txt" -2.3 2.7) :to-equal "line4\nline5"))
+
+      (it "handles float values with show-line-numbers parameter"
+        ;; Create test file for this test
+        (write-region "line1\nline2\nline3\nline4" nil (expand-file-name "multiline.txt" temp-dir))
+        ;; 1.8 should round to 2, 2.4 should round to 2.
+        (expect
+         (macher--tool-read-file context "multiline.txt" 1.8 2.4 t)
+         :to-equal "2\tline2\n3\tline3")
+        ;; -1.5 should round to -2 (line3 start), 1.9 should round to 2 (2 lines).
+        (expect
+         (macher--tool-read-file context "multiline.txt" -1.5 1.9 t)
+         :to-equal "3\tline3\n4\tline4"))
+
+      (it "handles edge case float values"
+        ;; Create a 3-line file for this test
+        (write-region "line1\nline2\nline3" nil (expand-file-name "threeline.txt" temp-dir))
+        ;; 0.4 should round to 0, which gets treated as 1.
+        (expect
+         (macher--tool-read-file context "threeline.txt" 0.4)
+         :to-equal "line1\nline2\nline3")
+        ;; 0.6 should round to 1.
+        (expect
+         (macher--tool-read-file context "threeline.txt" 0.6)
+         :to-equal "line1\nline2\nline3")
+        ;; Very small positive float should still round to 0 then treated as 1.
+        (expect
+         (macher--tool-read-file context "threeline.txt" 0.1)
+         :to-equal "line1\nline2\nline3")
+        ;; Very small negative float should round to limit 0.
+        (expect (macher--tool-read-file context "threeline.txt" nil -0.1) :to-equal ""))))
 
   (describe "macher--project-files"
     :var (temp-dir file1 file2 subdir file3 project-file)
@@ -313,7 +2457,7 @@
     (it "returns project files with relative paths"
       (funcall setup-project)
       (expect project-dir :to-be-truthy)
-      (let ((files (macher--project-files project-dir)))
+      (let ((files (macher--project-files (directory-file-name project-dir))))
         (expect files :to-be-truthy)
         (expect (listp files) :to-be-truthy)
         ;; Should contain relative paths.
@@ -353,11 +2497,18 @@
         (expect result :to-match "file1.txt")
         (expect result :to-match "file2.el")
         (expect result :to-match "subdir/file3.md")
-        ;; Should mark files in context with [*].
-        (expect result :to-match "\\[\\*\\] file1\\.txt")
-        (expect result :to-match "\\[\\*\\] file2\\.el")
-        ;; file3 should not be marked since it's not in contexts.
-        (expect result :to-match "    subdir/file3\\.md")
+        ;; Should distinguish between files in context and files available for editing.
+        ;; Files in context should be in "already provided" section with proper structure.
+        (expect
+         result
+         :to-match "Files already provided above.*\n\\(    [^\n]*\n\\)*    file1\\.txt")
+        (expect
+         result
+         :to-match "Files already provided above.*\n\\(    [^\n]*\n\\)*    file2\\.el")
+        ;; Files not in context should be in "available for editing" section.
+        (expect
+         result
+         :to-match "Other files available for editing:\n\\(    [^\n]*\n\\)*    subdir/file3\\.md")
         ;; Should contain workspace description.
         (expect result :to-match "In-memory editing environment")))
 
@@ -372,7 +2523,39 @@
         (expect result :to-match "file1.txt")
         ;; Should not contain other files.
         (expect result :not :to-match "file2.el")
-        (expect result :not :to-match "file3.md"))))
+        (expect result :not :to-match "file3.md")))
+
+    (it "properly categorizes files with same name in different directories"
+      (let* ((workspace '(project . "/test/project/"))
+             (workspace-files '("/test/project/test.txt" "/test/project/subdir/test.txt"))
+             (contexts '(("/test/project/test.txt")))
+             result)
+        ;; Mock workspace functions.
+        (spy-on 'macher--workspace-root :and-return-value "/test/project/")
+        (spy-on 'macher--workspace-name :and-return-value "test-project")
+        (spy-on 'macher--workspace-files :and-return-value workspace-files)
+
+        ;; Set the test workspace.
+        (with-temp-buffer
+          (setq-local macher--workspace workspace)
+          (setq result (macher--context-string contexts)))
+
+        ;; Verify the result structure.
+        (expect (stringp result) :to-be-truthy)
+        (expect result :to-match "WORKSPACE CONTEXT")
+
+        ;; test.txt should be in the "already provided" section since it's in contexts
+        (expect
+         result
+         :to-match "Files already provided above.*\n\\(    [^\n]*\n\\)*    test\\.txt")
+
+        ;; subdir/test.txt should be in "available for editing" since it's not in contexts
+        (expect
+         result
+         :to-match "Other files available for editing:\n\\(    [^\n]*\n\\)*    subdir/test\\.txt")
+
+        ;; Should contain workspace description
+        (expect result :to-match "In-memory editing environment"))))
 
   (describe "Workspace detection functions"
     (before-each
@@ -390,7 +2573,9 @@
           (let ((result (macher--project-workspace)))
             (expect result :to-be-truthy)
             (expect (car result) :to-be 'project)
-            (funcall expect-dirs-match (cdr result) project-dir))))
+            (expect
+             (directory-file-name (cdr result))
+             :to-equal (directory-file-name project-dir)))))
 
       (it "returns nil when not in a project"
         (with-temp-buffer
@@ -428,7 +2613,9 @@
           (let ((result (macher-workspace)))
             (expect result :to-be-truthy)
             (expect (car result) :to-be 'project)
-            (funcall expect-dirs-match (cdr result) project-dir))))
+            (expect
+             (directory-file-name (cdr result))
+             :to-equal (directory-file-name project-dir)))))
 
       (it "falls back to file workspace when no project found"
         (with-temp-buffer
@@ -486,7 +2673,9 @@
               (let ((result (macher-workspace test-buffer)))
                 (expect result :to-be-truthy)
                 (expect (car result) :to-be 'project)
-                (funcall expect-dirs-match (cdr result) project-dir))))))
+                (expect
+                 (directory-file-name (cdr result))
+                 :to-equal (directory-file-name project-dir)))))))
 
       ;; Test the actual default hook behavior.
       (describe "integration tests"
@@ -504,7 +2693,114 @@
             (let ((result (macher-workspace)))
               (expect result :to-be-truthy)
               (expect (car result) :to-be 'project)
-              (funcall expect-dirs-match (cdr result) project-dir)))))))
+              (expect
+               (directory-file-name (cdr result))
+               :to-equal (directory-file-name project-dir)))))))
+
+    (describe "macher--workspace-root"
+      (before-each
+        ;; Sanity checks.
+        (expect project-file :to-be-truthy)
+        (expect project-dir :to-be-truthy))
+
+      (it "throws error when workspace type is not in macher-workspace-types-alist"
+        (let ((macher-workspace-types-alist nil)
+              (test-workspace '(nonexistent-type . "/some/path")))
+          ;; Test macher--workspace-root
+          (expect (macher--workspace-root test-workspace) :to-throw 'error)
+          ;; Test macher--workspace-name
+          (expect (macher--workspace-name test-workspace) :to-throw 'error)
+          ;; Test macher--workspace-files
+          (expect (macher--workspace-files test-workspace) :to-throw 'error)))
+
+      (it "throws error when workspace type config is missing required functions"
+        ;; Test missing :get-root
+        (let ((macher-workspace-types-alist
+               '((test-type . (:get-name (lambda (id) "test") :get-files (lambda (id) nil)))))
+              (test-workspace '(test-type . "/some/path")))
+          (expect (macher--workspace-root test-workspace) :to-throw 'error))
+
+        ;; Test missing :get-name
+        (let ((macher-workspace-types-alist
+               '((test-type . (:get-root (lambda (id) "/some/root") :get-files (lambda (id) nil)))))
+              (test-workspace '(test-type . "/some/path")))
+          (expect (macher--workspace-name test-workspace) :to-throw 'error)))
+
+      (it "throws error when root function returns nil"
+        (let ((macher-workspace-types-alist
+               '((test-type
+                  .
+                  (:get-root
+                   (lambda (id) nil)
+                   :get-name (lambda (id) "test")
+                   :get-files (lambda (id) nil)))))
+              (test-workspace '(test-type . "/some/path")))
+          (expect (macher--workspace-root test-workspace) :to-throw 'error)))
+
+      (it "throws error when root function returns non-absolute path"
+        (let ((macher-workspace-types-alist
+               '((test-type
+                  .
+                  (:get-root
+                   (lambda (id) "relative/path")
+                   :get-name (lambda (id) "test")
+                   :get-files (lambda (id) nil)))))
+              (test-workspace '(test-type . "/some/path")))
+          (expect (macher--workspace-root test-workspace) :to-throw 'error)))
+
+      (it "throws error when root function returns path to non-existent directory"
+        (let ((macher-workspace-types-alist
+               '((test-type
+                  .
+                  (:get-root
+                   (lambda (id) "/nonexistent/directory")
+                   :get-name (lambda (id) "test")
+                   :get-files (lambda (id) nil)))))
+              (test-workspace '(test-type . "/some/path")))
+          (expect (macher--workspace-root test-workspace) :to-throw 'error)))
+
+      (it "throws error when root function returns path to a file instead of directory"
+        (let* ((temp-file (make-temp-file "macher-test-file"))
+               (macher-workspace-types-alist
+                `((test-type
+                   .
+                   (:get-root
+                    (lambda (id) ,temp-file)
+                    :get-name (lambda (id) "test")
+                    :get-files (lambda (id) nil)))))
+               (test-workspace '(test-type . "/some/path")))
+          (unwind-protect
+              (expect (macher--workspace-root test-workspace) :to-throw 'error)
+            ;; Clean up
+            (when (file-exists-p temp-file)
+              (delete-file temp-file)))))
+
+      (it "works correctly with valid workspace type configuration"
+        (let* ((temp-dir (make-temp-file "macher-test-workspace" t))
+               (macher-workspace-types-alist
+                `((test-type
+                   .
+                   (:get-root
+                    (lambda (id) ,temp-dir)
+                    :get-name (lambda (id) "Test Workspace")
+                    :get-files
+                    (lambda (id) '("file1.txt" "file2.txt"))))))
+               (test-workspace '(test-type . "/some/path")))
+          (unwind-protect
+              (progn
+                ;; All functions should work correctly
+                (expect (macher--workspace-root test-workspace) :to-equal temp-dir)
+                (expect (macher--workspace-name test-workspace) :to-equal "Test Workspace")
+                (let ((files (macher--workspace-files test-workspace)))
+                  (expect
+                   files
+                   :to-equal
+                   (list
+                    (expand-file-name "file1.txt" temp-dir)
+                    (expand-file-name "file2.txt" temp-dir)))))
+            ;; Clean up
+            (when (file-exists-p temp-dir)
+              (delete-directory temp-dir t)))))))
 
   (describe "macher--merge-tools"
     (before-each
@@ -1311,14 +3607,316 @@
                    (setf (macher-action-execution-context execution) test-context)))))
           ;; Call macher-action with the original prompt.
           (macher-action 'implement original-prompt)
-          ;; Verify gptel-request was called
+          ;; Verify gptel-request was called.
           (expect 'gptel-request :to-have-been-called)
           ;; Get the arguments passed to gptel-request.
           (let* ((call-args (spy-calls-args-for 'gptel-request 0))
                  (call-plist (cdr call-args))
                  (passed-context (plist-get call-plist :context)))
             ;; The :context key should contain our test context.
-            (expect passed-context :to-equal test-context)))))))
+            (expect passed-context :to-equal test-context))))))
+
+  (describe "macher--resolve-workspace-path"
+    :var
+    (temp-workspace-root
+     temp-file1 temp-file2 temp-subdir temp-subfile project-workspace file-workspace)
+
+    (before-each
+      ;; Create temporary workspace structure.
+      (setq temp-workspace-root (make-temp-file "macher-workspace-test" t))
+      (setq temp-file1 (expand-file-name "file1.txt" temp-workspace-root))
+      (setq temp-file2 (expand-file-name "file2.txt" temp-workspace-root))
+      (setq temp-subdir (expand-file-name "subdir" temp-workspace-root))
+      (setq temp-subfile (expand-file-name "subfile.txt" temp-subdir))
+
+      ;; Create files and directories.
+      (write-region "content1" nil temp-file1)
+      (write-region "content2" nil temp-file2)
+      (make-directory temp-subdir)
+      (write-region "subcontent" nil temp-subfile)
+
+      ;; Create project marker.
+      (write-region "" nil (expand-file-name ".project" temp-workspace-root))
+
+      ;; Set up workspace objects.
+      (setq project-workspace `(project . ,(directory-file-name temp-workspace-root)))
+      (setq file-workspace `(file . ,temp-file1)))
+
+    (after-each
+      ;; Clean up.
+      (when (file-exists-p temp-workspace-root)
+        (delete-directory temp-workspace-root t)))
+
+    (it "resolves basic relative paths"
+      (let ((result (macher--resolve-workspace-path project-workspace "file1.txt")))
+        (expect result :to-equal temp-file1))
+
+      (let ((result (macher--resolve-workspace-path project-workspace "subdir/subfile.txt")))
+        (expect result :to-equal temp-subfile)))
+
+    (it "resolves '.' to workspace root"
+      (let ((result (macher--resolve-workspace-path project-workspace ".")))
+        (expect result :to-equal temp-workspace-root)))
+
+    (it "handles './' prefix correctly"
+      (let ((result (macher--resolve-workspace-path project-workspace "./file1.txt")))
+        (expect result :to-equal temp-file1)))
+
+    (it "handles .. path components"
+      (let ((result (macher--resolve-workspace-path project-workspace "subdir/../file1.txt")))
+        (expect result :to-equal temp-file1)))
+
+    (it "returns path for non-existent files without error"
+      (let ((result (macher--resolve-workspace-path project-workspace "nonexistent.txt")))
+        (expect result :to-equal (expand-file-name "nonexistent.txt" temp-workspace-root))))
+
+    (it "throws error for paths that escape workspace root"
+      (expect (macher--resolve-workspace-path project-workspace "../outside.txt") :to-throw)
+      (expect (macher--resolve-workspace-path project-workspace "/etc/passwd") :to-throw))
+
+    (it "throws error for existing files not in workspace files list"
+      ;; Create an extra file that won't be in the project files list.
+      (let ((extra-file (expand-file-name "extra.txt" temp-workspace-root)))
+        (write-region "extra content" nil extra-file)
+
+        ;; Spy on macher--workspace-files to exclude extra.txt from the files list.
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace)
+           ;; Get the actual files from the real function but filter out extra.txt.
+           (let ((files (macher--project-files (cdr workspace))))
+             (cl-remove-if (lambda (file) (string-match-p "extra\\.txt$" file)) files))))
+
+        ;; Should succeed for files that are in the project.
+        (let ((result (macher--resolve-workspace-path project-workspace "file1.txt")))
+          (expect result :to-equal temp-file1))
+
+        ;; Should fail for existing files not in the project.
+        (expect (macher--resolve-workspace-path project-workspace "extra.txt") :to-throw)))
+
+    (it "handles special characters in paths"
+      ;; Create file with special characters.
+      (let ((special-file (expand-file-name "file with spaces & symbols!.txt" temp-workspace-root)))
+        (write-region "special content" nil special-file)
+
+        ;; Add it to the project by updating the .project marker (forces project-files to re-scan).
+        (write-region "updated" nil (expand-file-name ".project" temp-workspace-root))
+
+        (let ((result
+               (macher--resolve-workspace-path
+                project-workspace "file with spaces & symbols!.txt")))
+          (expect result :to-equal special-file))))
+
+    (it "allows symlinks as final component"
+      (let ((symlink-path (expand-file-name "test-symlink" temp-workspace-root)))
+        (make-symbolic-link temp-file1 symlink-path)
+
+        ;; Mock workspace files to include the symlink.
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace) (append (macher--project-files (cdr workspace)) (list symlink-path))))
+
+        (let ((result (macher--resolve-workspace-path project-workspace "test-symlink")))
+          (expect result :to-equal symlink-path))))
+
+    (it "throws error for symlinks in non-final path components"
+      (let ((symlink-dir (expand-file-name "symlink-dir" temp-workspace-root))
+            (target-dir (expand-file-name "target" temp-workspace-root))
+            (target-file
+             (expand-file-name "target.txt" (expand-file-name "target" temp-workspace-root))))
+
+        ;; Create target directory and file.
+        (make-directory target-dir)
+        (write-region "target content" nil target-file)
+
+        ;; Create symlink to directory.
+        (make-symbolic-link target-dir symlink-dir)
+
+        ;; Should throw error when accessing through symlinked directory.
+        (expect
+         (macher--resolve-workspace-path project-workspace "symlink-dir/target.txt")
+         :to-throw)))
+
+    (it "throws error for files in non-final path components"
+      ;; Create a file within the workspace that will be used as a non-final path component.
+      (let ((file-in-path (expand-file-name "not-a-dir" temp-workspace-root)))
+        (write-region "file content" nil file-in-path)
+
+        ;; Should throw error when trying to access through the file as if it were a directory.
+        (expect
+         (macher--resolve-workspace-path project-workspace "not-a-dir/target.txt")
+         :to-throw)))
+
+    (it "handles absolute paths within workspace"
+      (let ((result (macher--resolve-workspace-path project-workspace temp-file1)))
+        (expect result :to-equal temp-file1)))
+
+    (it "handles paths with multiple slashes"
+      (let ((result (macher--resolve-workspace-path project-workspace "subdir//subfile.txt")))
+        (expect result :to-equal temp-subfile)))
+
+    (it "handles empty string path"
+      (let ((result (macher--resolve-workspace-path project-workspace "")))
+        (expect result :to-equal temp-workspace-root)))
+
+    (it "allows access to workspace directories even if not in files list"
+      ;; Directories should always be accessible, even if not in the files list.
+      (let ((result (macher--resolve-workspace-path project-workspace ".")))
+        (expect result :to-equal temp-workspace-root))
+      ;; Test subdirectories too.
+      (let ((result (macher--resolve-workspace-path project-workspace "subdir")))
+        (expect result :to-equal temp-subdir)))
+
+    (it "allows access to nested workspace directories even if not in files list"
+      ;; Create a nested directory structure that won't be in the project files list.
+      (let ((nested-dir (expand-file-name "very/deep/nested/dir" temp-workspace-root)))
+        (make-directory nested-dir t)
+        (let ((result (macher--resolve-workspace-path project-workspace "very/deep/nested/dir")))
+          (expect result :to-equal nested-dir))
+        ;; Test intermediate directories too.
+        (let ((result (macher--resolve-workspace-path project-workspace "very/deep")))
+          (expect result :to-equal (expand-file-name "very/deep" temp-workspace-root)))
+        ;; Clean up.
+        (delete-directory (expand-file-name "very" temp-workspace-root) t)))
+
+    (it "allows files outside workspace if in workspace files list"
+      (let ((outside-file (make-temp-file "macher-test-outside-")))
+        ;; Create the outside file with content.
+        (write-region "outside content" nil outside-file)
+
+        (unwind-protect
+            (progn
+              ;; Mock workspace files to include the outside file - this is one case where spy is
+              ;; needed since we can't actually add files outside the project to a real project.
+              (spy-on 'macher--workspace-files :and-return-value (list outside-file))
+
+              (let ((result (macher--resolve-workspace-path project-workspace outside-file)))
+                (expect result :to-equal outside-file)))
+
+          ;; Clean up.
+          (when (file-exists-p outside-file)
+            (delete-file outside-file)))))
+
+    (it "rejects files and directories outside workspace if not in workspace files list"
+      ;; File outside workspace should fail if not in files list.
+      (let ((outside-file (make-temp-file "macher-test-outside-file-")))
+        (write-region "outside content" nil outside-file)
+        (unwind-protect
+            ;; Should throw error - file is outside workspace and not in files list.
+            (expect (macher--resolve-workspace-path project-workspace outside-file) :to-throw)
+          ;; Clean up.
+          (when (file-exists-p outside-file)
+            (delete-file outside-file))))
+
+      ;; Directory outside workspace should fail even if it exists.
+      (let ((outside-dir (make-temp-file "macher-test-outside-dir-" t)))
+        (unwind-protect
+            ;; Should throw error - directory is outside workspace.
+            (expect (macher--resolve-workspace-path project-workspace outside-dir) :to-throw)
+          ;; Clean up.
+          (when (file-exists-p outside-dir)
+            (delete-directory outside-dir))))
+
+      ;; Non-existent directory outside workspace should also fail.
+      (let ((non-existent-dir
+             (file-name-directory
+              (expand-file-name "non-existent-dir/that-should-not-exist"
+                                (temporary-file-directory)))))
+        (expect (macher--resolve-workspace-path project-workspace non-existent-dir) :to-throw)))
+
+    (it "handles broken symlinks"
+      (let ((broken-symlink (expand-file-name "broken-symlink" temp-workspace-root)))
+        (make-symbolic-link "/nonexistent/target" broken-symlink)
+
+        ;; Mock workspace files to include the broken symlink.
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace)
+           (append (macher--project-files (cdr workspace)) (list broken-symlink))))
+
+        (let ((result (macher--resolve-workspace-path project-workspace "broken-symlink")))
+          (expect result :to-equal broken-symlink))
+
+        ;; Clean up.
+        (delete-file broken-symlink)))
+
+    (it "throws error for existing symlinks not in workspace files list"
+      ;; Create a symlink that exists but won't be in the project files list
+      (let ((untracked-symlink (expand-file-name "untracked-symlink" temp-workspace-root))
+            (target-file (expand-file-name "target-for-untracked.txt" temp-workspace-root)))
+        ;; Create the target file.
+        (write-region "target content" nil target-file)
+        ;; Create the symlink.
+        (make-symbolic-link target-file untracked-symlink)
+
+        ;; Spy on macher--workspace-files to exclude the symlink from the files list.
+        (spy-on
+         'macher--workspace-files
+         :and-call-fake
+         (lambda (workspace)
+           ;; Get the actual files from the real function but filter out the symlink.
+           (let ((files (macher--project-files (cdr workspace))))
+             (cl-remove-if (lambda (file) (string-match-p "untracked-symlink$" file)) files))))
+
+        (unwind-protect
+            ;; Should throw error - symlink exists but is not in the workspace files list.
+            (expect
+             (macher--resolve-workspace-path project-workspace "untracked-symlink")
+             :to-throw)
+          ;; Clean up
+          (when (file-exists-p untracked-symlink)
+            (delete-file untracked-symlink))
+          (when (file-exists-p target-file)
+            (delete-file target-file)))))
+
+    (it "resolves paths correctly for workspaces under '~'"
+      ;; If the workspace root contains an expandable segment like "~", make sure we can still
+      ;; resolve files within it.
+      (let* ((mock-workspace-root "~/projects/test-project/")
+             (mock-file1 (concat mock-workspace-root "src/main.el"))
+             (mock-file2 (concat mock-workspace-root "README.md"))
+             (home-workspace `(project . ,mock-workspace-root)))
+
+        ;; Mock workspace-files to return our fake file list.
+        (spy-on 'macher--workspace-files :and-return-value (list mock-file1 mock-file2))
+
+        ;; Mock workspace-root to return our fake root.
+        (spy-on 'macher--workspace-root :and-return-value mock-workspace-root)
+
+        ;; Test resolving "." to workspace root.
+        (let ((result (macher--resolve-workspace-path home-workspace ".")))
+          (expect result :to-equal (directory-file-name (expand-file-name mock-workspace-root))))
+
+        ;; Test resolving "" to workspace root.
+        (let ((result (macher--resolve-workspace-path home-workspace ".")))
+          (expect result :to-equal (directory-file-name (expand-file-name mock-workspace-root))))
+
+        ;; Test resolving relative paths to non-existing files (should not throw).
+        (let ((result (macher--resolve-workspace-path home-workspace "src/new-file.el")))
+          (expect result :to-equal (expand-file-name "src/new-file.el" mock-workspace-root)))
+
+        ;; Test resolving paths with "./" prefix.
+        (let ((result (macher--resolve-workspace-path home-workspace "./README.md")))
+          (expect result :to-equal (expand-file-name mock-file2)))
+
+        ;; Test resolving paths with ".." components.
+        (let ((result (macher--resolve-workspace-path home-workspace "src/../README.md")))
+          (expect result :to-equal (expand-file-name mock-file2)))
+
+        ;; Test that paths trying to escape the workspace still fail.
+        (expect (macher--resolve-workspace-path home-workspace "../outside.txt") :to-throw)
+        (expect (macher--resolve-workspace-path home-workspace "../../etc/passwd") :to-throw)
+
+        ;; Test absolute paths within the mock workspace.
+        (let ((result (macher--resolve-workspace-path home-workspace mock-file1)))
+          (expect result :to-equal (expand-file-name mock-file1)))
+
+        ;; Test that absolute paths outside the workspace fail (even under home).
+        (let ((outside-home-path (expand-file-name "other-project/file.txt" "~")))
+          (expect (macher--resolve-workspace-path home-workspace outside-home-path) :to-throw))))))
 
 
 ;; Local variables:


### PR DESCRIPTION
These changes should hopefully improve the efficiency of macher operations - for example, it's now possible for the LLM to read parts of files rather than only files in their entirety. The new search tool also allows the LLM to be more dynamic in its investigation of the workspace.

More complete list of changes:

- Add a new grep-style search tool which uses `xref-matches-in-files` to search by regexp

- Add a tool to list directory contents

- Add limit/offset/show-line-numbers parameters to the read tool

- Split the edit tool into separate edit/multi-edit tools, so the LLM doesn't always have to pass an array of edits

- Improve path resolution during tool use, including more strict checks to prevent the LLM from accessing files that aren't in the current workspace's files list (even if they're under the workspace root, e.g. gitignore'd files)

- Update tool/argument descriptions and the default context string that gets passed with requests, to make the workspace abstraction (hopefully) easier for the LLM to understand

- Internal/organizational cleanup for tool definitions

- More extensive tests for tool functionality