### PR TITLE
fix: Simplify language detection

### DIFF
--- a/macher.el
+++ b/macher.el
@@ -3095,10 +3095,12 @@ IS-SELECTED specifies whether the input comes from the selected region."
            ;; Regular file case.
            (t
             (let* ((lang
-                    (downcase
-                     (if-let* ((mode-string (format "%s" major-mode))
-                               (match-index (string-match "-mode$" mode-string)))
-                         (substring mode-string 0 match-index)
+                    ;; Use gptel's internal mode formatting method, with a fallback on error in case
+                    ;; the method gets removed or the signature changes (errors should also be
+                    ;; picked up by tests, so we'll notice such a change eventually).
+                    (condition-case nil
+                        (gptel--strip-mode-suffix major-mode)
+                      (error
                        (format-mode-line mode-name)))))
               (format (concat
                        "The request was sent from the %s file `%s` in the workspace. "

--- a/macher.el
+++ b/macher.el
@@ -3096,9 +3096,10 @@ IS-SELECTED specifies whether the input comes from the selected region."
            (t
             (let* ((lang
                     (downcase
-                     (if (stringp mode-name)
-                         mode-name
-                       (car mode-name)))))
+                     (if-let* ((mode-string (format "%s" major-mode))
+                               (match-index (string-match "-mode$" mode-string)))
+                         (substring mode-string 0 match-index)
+                       (format-mode-line mode-name)))))
               (format (concat
                        "The request was sent from the %s file `%s` in the workspace. "
                        "If the request text appears as a comment or placeholder in the file, "


### PR DESCRIPTION
Originally, this aimed to simply support `delight`-ed modes -- [such as with a heavily customized mode-line](
https://emacs.stackexchange.com/questions/20605/how-to-delight-major-mode-strings-when-using-powerline-with-use-package). However, it seems to work more generally to use `major-mode` as the condition variable, leaving `mode-name` as a fallback.