### PR TITLE
feat: remove handling for older action format

### DIFF
--- a/macher.el
+++ b/macher.el
@@ -3823,18 +3823,6 @@ implements one possible workflow."
       (unless action-config
         (error "Unknown action: %s" action))
 
-      ;; Handle the older action format with a warning. This fallback will be removed in a future
-      ;; update.
-      (when (plist-get action-plist :transform)
-        (warn
-         (concat
-          "The format for entries in the macher-actions-plist has changed."
-          "See the docstring for details."
-          "Please update the definition for action '%s'."))
-        (setq action-plist
-              (macher-action-from-region-or-input
-               (plist-get action-plist :prompt) (plist-get action-plist :transform))))
-
       (let* ((prompt (plist-get action-plist :prompt))
              (preset (or (plist-get action-plist :preset) 'macher))
              (summary (plist-get action-plist :summary))


### PR DESCRIPTION
This only affects you if you're using custom actions and are using the format from before 5cac12e8160c657e15dda009328978c35a90bf3a.

You would have seen warnings in your Messages buffer if your definitions are still using the old format. If you haven't seen warnings, this probably doesn't affect you.

See 5cac12e8160c657e15dda009328978c35a90bf3a for an example of the difference between formats, in case you still need to migrate.