### PR TITLE
chore: bump gptel depencency version

### DIFF
--- a/Eask
+++ b/Eask
@@ -13,7 +13,7 @@
 (source "melpa")
 
 (depends-on "emacs" "30.1")
-(depends-on "gptel" "0.9.8.5")
+(depends-on "gptel" "0.9.9.3")
 
 (development
  (depends-on "buttercup")

--- a/macher.el
+++ b/macher.el
@@ -4,7 +4,7 @@
 
 ;; Author: Kevin Montag
 ;; Version: 0.5.0
-;; Package-Requires: ((emacs "30.1") (gptel "0.9.8.5"))
+;; Package-Requires: ((emacs "30.1") (gptel "0.9.9.3"))
 ;; Keywords: convenience, gptel, llm
 ;; URL: https://github.com/kmontag/macher
 


### PR DESCRIPTION
The latest macher stuff requires a recent gptel.