### PR TITLE
fix: include new/deleted file metadata lines in patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,3 +251,12 @@ You can see customizable variables/sub-groups with `M-x customize-group RET mach
 | `macher-presets-alist`     | Preset definitions (macher, macher-ro, etc.) |
 | `macher-tool-category`     | Category for macher tools in gptel registry  |
 | `macher-match-max-columns` | Max line length for search results           |
+
+## FAQ
+
+### Why does `diff-apply-buffer` misbehave when the patch contains new or deleted files?
+
+`diff-mode` in Emacs 30.x and below doesn't handle file creations/deletions well. The issue has been
+fixed upstream, and the fix will likely be included in the next major Emacs release. In the
+meantime, if this case comes up often for you, see
+[#45](https://github.com/kmontag/macher/issues/45) for possible workarounds.

--- a/macher.el
+++ b/macher.el
@@ -3156,6 +3156,15 @@ CONTEXT is the `macher-context' object.  Returns the generated diff text."
               ;; Add the standard git diff header, which allows diff-mode to create new files.
               (insert (format "diff --git a/%s b/%s\n" rel-path rel-path))
 
+              ;; Add file mode lines for new or deleted files.
+              (cond
+               ;; New file: orig-content is nil, new-content is non-nil.
+               ((and (not orig-content) new-content)
+                (insert "new file mode 100644\n"))
+               ;; Deleted file: orig-content is non-nil, new-content is nil.
+               ((and orig-content (not new-content))
+                (insert "deleted file mode 100644\n")))
+
               ;; Use diff to generate a unified patch with the correct file path.
               (when (or orig-content new-content)
                 (call-process "diff"

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -3636,10 +3636,10 @@ Sets `test-patch-content' to the generated patch content for additional assertio
                       nil
                       nil
                       nil
-                       ;; The -E flag causes empty files to be deleted. Note this means we're not
-                       ;; quite testing that the patch contains a "true" deletion, but this flag is
-                       ;; needed for consistent behavior between GNU patch and e.g. MacOS patch
-                       ;; (which doesn't delete any files by default).
+                      ;; The -E flag causes empty files to be deleted. Note this means we're not
+                      ;; quite testing that the patch contains a "true" deletion, but this flag is
+                      ;; needed for consistent behavior between GNU patch and e.g. MacOS patch
+                      ;; (which doesn't delete any files by default).
                       "-E"
                       "-p1"
                       "-d"

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -1081,6 +1081,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
               (expect (regexp-quote
                        (concat
                         "diff --git a/test-file.txt b/test-file.txt\n"
+                        "deleted file mode 100644\n"
                         "--- a/test-file.txt\n"
                         "+++ /dev/null\n"
                         "@@ -1,1 +0,0 @@\n"
@@ -1201,6 +1202,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
               (expect (regexp-quote
                        (concat
                         "diff --git a/created-file.txt b/created-file.txt\n"
+                        "new file mode 100644\n"
                         "--- /dev/null\n"
                         "+++ b/created-file.txt\n"
                         "@@ -0,0 +1,1 @@\n"
@@ -1404,6 +1406,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
               (expect (regexp-quote
                        (concat
                         "diff --git a/moved-file.txt b/moved-file.txt\n"
+                        "new file mode 100644\n"
                         "--- /dev/null\n"
                         "+++ b/moved-file.txt\n"
                         "@@ -0,0 +1,1 @@\n"
@@ -1414,6 +1417,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
               (expect (regexp-quote
                        (concat
                         "diff --git a/source-file.txt b/source-file.txt\n"
+                        "deleted file mode 100644\n"
                         "--- a/source-file.txt\n"
                         "+++ /dev/null\n"
                         "@@ -1,1 +0,0 @@\n"
@@ -3518,6 +3522,7 @@ Sets `test-patch-content' to the generated patch content for additional assertio
               (expect (regexp-quote
                        (concat
                         "diff --git a/created.txt b/created.txt\n"
+                        "new file mode 100644\n"
                         "--- /dev/null\n"
                         "+++ b/created.txt\n"
                         "@@ -0,0 +1,1 @@\n"

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -3668,7 +3668,7 @@ Sets `test-patch-content' to the generated patch content for additional assertio
                   (expect (file-exists-p deleted-file) :not :to-be-truthy))
 
                 ;; Verify directory contains exactly the expected files.
-                (let* ((all-files (directory-files project-dir nil "^[^.]"))
+                (let* ((all-files (directory-files project-dir nil "\\`[^.]"))
                        (sorted-files (sort all-files #'string<)))
                   (expect sorted-files :to-equal '("created.txt" "modified.txt")))))
 

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -3577,6 +3577,105 @@ Sets `test-patch-content' to the generated patch content for additional assertio
               (expect patch :not :to-match "@@")
               (expect patch :not :to-match "^[+-]")))))))
 
+  (describe "patch application"
+    (it "applies generated patches with mixed operations using the patch command"
+      (funcall setup-backend
+               `((:tool-calls
+                  [(:function
+                    (:name
+                     "edit_file_in_workspace"
+                     :arguments
+                     (:path
+                      "modified.txt"
+                      :old_text "original content\n"
+                      :new_text "modified content\n")))
+                   (:function
+                    (:name
+                     "write_file_in_workspace"
+                     :arguments (:path "created.txt" :content "new file content\n")))
+                   (:function (:name "delete_file_in_workspace" :arguments (:path "deleted.txt")))])
+                 "Made all requested changes"))
+      (funcall setup-project
+               "patch-apply-test"
+               '(("modified.txt" . "original content\n") ("deleted.txt" . "content to delete\n")))
+
+      (let ((callback-called nil)
+            (exit-code nil)
+            (fsm nil)
+            (patch-file (make-temp-file "macher-patch" nil ".patch")))
+        (unwind-protect
+            (with-temp-buffer
+              (set-visited-file-name project-file)
+              (macher-test--send
+               'macher "Make mixed file changes"
+               (macher-test--make-once-only-callback
+                (lambda (cb-exit-code cb-fsm)
+                  (setq callback-called t)
+                  (setq exit-code cb-exit-code)
+                  (setq fsm cb-fsm))))
+
+              ;; Wait for the async response.
+              (let ((timeout 0))
+                (while (and (not callback-called) (< timeout 100))
+                  (sleep-for 0.1)
+                  (setq timeout (1+ timeout))))
+
+              (expect callback-called :to-be-truthy)
+              (expect exit-code :to-be nil)
+              (expect (gptel-fsm-state fsm) :to-be 'DONE)
+
+              ;; Save the patch to a file.
+              (with-current-buffer (macher-patch-buffer)
+                (write-region (point-min) (point-max) patch-file))
+
+              ;; Apply patch directly to the project directory using the patch command.
+              ;; Use -E to remove empty files (for deletions).
+              (let ((patch-exit-code
+                     (call-process
+                      "patch"
+                      nil
+                      nil
+                      nil
+                       ;; The -E flag causes empty files to be deleted. Note this means we're not
+                       ;; quite testing that the patch contains a "true" deletion, but this flag is
+                       ;; needed for consistent behavior between GNU patch and e.g. MacOS patch
+                       ;; (which doesn't delete any files by default).
+                      "-E"
+                      "-p1"
+                      "-d"
+                      project-dir
+                      "-i"
+                      patch-file)))
+                ;; Verify patch applied successfully.
+                (expect patch-exit-code :to-equal 0)
+
+                ;; Verify modified file has new content.
+                (let ((modified-file (expand-file-name "modified.txt" project-dir)))
+                  (expect (file-exists-p modified-file) :to-be-truthy)
+                  (with-temp-buffer
+                    (insert-file-contents modified-file)
+                    (expect (buffer-string) :to-equal "modified content\n")))
+
+                ;; Verify created file exists with correct content.
+                (let ((created-file (expand-file-name "created.txt" project-dir)))
+                  (expect (file-exists-p created-file) :to-be-truthy)
+                  (with-temp-buffer
+                    (insert-file-contents created-file)
+                    (expect (buffer-string) :to-equal "new file content\n")))
+
+                ;; Verify deleted file no longer exists.
+                (let ((deleted-file (expand-file-name "deleted.txt" project-dir)))
+                  (expect (file-exists-p deleted-file) :not :to-be-truthy))
+
+                ;; Verify directory contains exactly the expected files.
+                (let* ((all-files (directory-files project-dir nil "^[^.]"))
+                       (sorted-files (sort all-files #'string<)))
+                  (expect sorted-files :to-equal '("created.txt" "modified.txt")))))
+
+          ;; Cleanup.
+          (when (file-exists-p patch-file)
+            (delete-file patch-file))))))
+
   (describe "macher context sharing"
     (it "shares single context when multiple tools are invoked together"
       (funcall setup-backend


### PR DESCRIPTION
This allows patches to be applied cleanly with e.g. `patch` or `git apply` in cases where files are created or deleted.

Note these metadata lines aren't currently recognized in any special way by `diff-mode` - this is just to make the patch more generally semantically correct.

Fixes #45.