### PR TITLE
feat: include customizable/yankable focus string in action prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ All built-in presets can safely be repeatedly applied.
 
 Actions are convenience commands that use macher presets with a specific workflow:
 
-- A prompt is captured based on the current selection/cursor position.
+- A description of your current location in the code is generated (see `macher-focus-description`).
+- A prompt is captured based on the current selection or manual input.
 - The prompt is sent in a dedicated actions buffer, with a macher preset applied.
 
 The built-in actions are:
@@ -126,11 +127,21 @@ The built-in actions are:
 
 - **`macher-action`**: Run any action from the `macher-actions-alist`.
 - **`macher-abort`**: Cancel running action requests for the current workspace.
+- **`macher-focus-description`**: Get a description of your current code location. When called
+  interactively, yanks the description to the kill ring. Useful for manually pasting context into
+  conversations.
 
 The actions buffer UI can be customized with `macher-action-buffer-ui` (see
 [Customization](#customization)).
 
 You can define custom actions in `macher-actions-alist`.
+
+#### Focus description
+
+When you run an action, macher automatically generates a description of your current location in the
+code - the file you're in, your cursor position or selection, and relevant context. This is
+controlled by `macher-focus-description`, which can be customized to change how this information is
+formatted or what details are included.
 
 ### Workspace context
 
@@ -215,6 +226,7 @@ You can see customizable variables/sub-groups with `M-x customize-group RET mach
 | Variable                          | Description                                                         |
 | --------------------------------- | ------------------------------------------------------------------- |
 | `macher-actions-alist`            | Defines available actions (implement, revise, discuss, etc.)        |
+| `macher-focus-description`        | Function to generate description of current code location           |
 | `macher-action-buffer-ui`         | UI style for action buffers: `'default`, `'org`, `'basic`, or `nil` |
 | `macher-action-buffer-setup-hook` | Hook run when creating action buffers                               |
 | `macher-action-dispatch-hook`     | Hook run when invoking an action                                    |

--- a/README.md
+++ b/README.md
@@ -128,20 +128,12 @@ The built-in actions are:
 - **`macher-action`**: Run any action from the `macher-actions-alist`.
 - **`macher-abort`**: Cancel running action requests for the current workspace.
 - **`macher-focus-description`**: Get a description of your current code location. When called
-  interactively, yanks the description to the kill ring. Useful for manually pasting context into
-  conversations.
+  interactively, yanks the description to the kill ring.
 
 The actions buffer UI can be customized with `macher-action-buffer-ui` (see
 [Customization](#customization)).
 
 You can define custom actions in `macher-actions-alist`.
-
-#### Focus description
-
-When you run an action, macher automatically generates a description of your current location in the
-code - the file you're in, your cursor position or selection, and relevant context. This is
-controlled by `macher-focus-description`, which can be customized to change how this information is
-formatted or what details are included.
 
 ### Workspace context
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ All built-in presets can safely be repeatedly applied.
 
 Actions are convenience commands that use macher presets with a specific workflow:
 
-- A description of your current location in the code is generated (see `macher-focus-description`).
+- A description of your current location in the code is generated (see `macher-focus-string`).
 - A prompt is captured based on the current selection or manual input.
 - The prompt is sent in a dedicated actions buffer, with a macher preset applied.
 
@@ -127,7 +127,7 @@ The built-in actions are:
 
 - **`macher-action`**: Run any action from the `macher-actions-alist`.
 - **`macher-abort`**: Cancel running action requests for the current workspace.
-- **`macher-focus-description`**: Get a description of your current code location. When called
+- **`macher-focus-string`**: Get a description of your current code location. When called
   interactively, yanks the description to the kill ring.
 
 The actions buffer UI can be customized with `macher-action-buffer-ui` (see
@@ -218,7 +218,7 @@ You can see customizable variables/sub-groups with `M-x customize-group RET mach
 | Variable                          | Description                                                         |
 | --------------------------------- | ------------------------------------------------------------------- |
 | `macher-actions-alist`            | Defines available actions (implement, revise, discuss, etc.)        |
-| `macher-focus-description`        | Function to generate description of current code location           |
+| `macher-focus-string`             | Function to generate description of current code location           |
 | `macher-action-buffer-ui`         | UI style for action buffers: `'default`, `'org`, `'basic`, or `nil` |
 | `macher-action-buffer-setup-hook` | Hook run when creating action buffers                               |
 | `macher-action-dispatch-hook`     | Hook run when invoking an action                                    |

--- a/macher.el
+++ b/macher.el
@@ -503,6 +503,47 @@ This hook runs after the callback provided to `macher-action' (if any)."
 
 ;;;; Context
 
+(defcustom macher-source-description #'macher--source-description-default
+  "Get a description of the source and the user's current focus.
+
+This will be evaluated when generating prompts for built-in actions, or
+when calling function `macher-source-description' directly.  It can be a
+sexp form or a function.
+
+The result should be a string providing contextual information about the
+current buffer (for example the file being visited) and the user's
+focus (for example the position of point and/or the selected region).
+
+By default, this uses `macher--source-description-default' which generates
+structured source information including:
+
+- File path (relative to workspace root)
+- Programming language
+- Cursor position (line and column) or selected region
+- Context text (text before cursor or selected text)
+
+The information is formatted as XML-like tags for easy parsing.
+
+You can customize this to provide alternative context, for example:
+
+  (setq macher-source-description
+        \\='(format \"Working in %s at line %d\"
+                 (buffer-name)
+                 (line-number-at-pos)))
+
+Or use a custom function:
+
+  (defun my-source-description ()
+    (format \"File: %s\\nTime: %s\"
+            (buffer-file-name)
+            (current-time-string)))
+
+  (setq macher-source-description #\\='my-source-description)
+
+Call `macher-source-description' interactively to yank this value."
+  :type '(choice (function :tag "Function to call") (sexp :tag "Form to evaluate"))
+  :group 'macher-actions)
+
 (defcustom macher-context-string-placeholder "\n[macher_placeholder]\n"
   "A placeholder in the system prompt for the macher context string.
 
@@ -3277,44 +3318,72 @@ otherwise returns (nil . nil)."
           content-pair)))))
 
 ;;; Default Prompt Functions
+(defun macher--source-description-default ()
+  "Build structured source information for the current buffer and cursor/selection.
 
-(defun macher--implement-prompt (input _is-selected)
-  "Generate an implementation prompt for INPUT in the current buffer."
+Returns a string containing XML-tagged source information, or nil if
+there's no relevant source info to include."
   (let* ((workspace (macher-workspace))
          (filename (buffer-file-name))
-         (relpath
-          (when filename
-            (file-relative-name filename (macher--workspace-root workspace))))
-         (source-description
-          (cond
-           ;; No file associated with buffer.
-           ((null filename)
-            "")
-           ;; Directory case.
-           ((file-directory-p filename)
-            (format "The request was sent from the workspace directory `%s`. " relpath))
-           ;; Regular file case.
-           (t
-            (let* ((lang
-                    ;; Use gptel's internal mode formatting method, with a fallback on error in case
-                    ;; the method gets removed or the signature changes (errors should also be
-                    ;; picked up by tests, so we'll notice such a change eventually).
-                    (condition-case nil
-                        (gptel--strip-mode-suffix major-mode)
-                      (error
-                       (format-mode-line mode-name)))))
-              (concat
-               (format "The request was sent from the %s file `%s` in the workspace. " lang relpath)
-               "If the request text appears as a comment or placeholder in the file, "
-               "replace it with the actual implementation. "))))))
+         (dirname dired-directory)
+         (parts nil))
+    (cond
+     ;; Standard file-visiting buffer.
+     (filename
+      (let* ((lang
+              (condition-case nil
+                  (gptel--strip-mode-suffix major-mode)
+                (error
+                 (format-mode-line mode-name))))
+             (has-selection (use-region-p)))
+        ;; File and language.
+        (push
+         (format "file: %s" (file-relative-name filename (macher--workspace-root workspace))) parts)
+        (push (format "language: %s" lang) parts)
+
+        (if has-selection
+            ;; Selection case.
+            (let* ((start (region-beginning))
+                   (end (region-end))
+                   (start-line (line-number-at-pos start))
+                   (end-line (line-number-at-pos end))
+                   (selected-text (buffer-substring-no-properties start end)))
+              (if (= start-line end-line)
+                  (push (format "line: %d" start-line) parts)
+                (push (format "lines: %d-%d" start-line end-line) parts))
+              (push (format "selection:\n%s" selected-text) parts))
+          ;; No selection - show cursor position and current line.
+          (let* ((pos (point))
+                 (line (line-number-at-pos pos))
+                 (col (current-column))
+                 (line-start (line-beginning-position))
+                 (text-before-cursor (buffer-substring-no-properties line-start pos)))
+            (push (format "line: %d, column: %d" line col) parts)
+            (when (not (string-empty-p text-before-cursor))
+              (push (format "text before cursor:\n%s" text-before-cursor) parts))))))
+     ;; Dired directory.
+     (dirname
+      (push (format "directory: %s" (file-relative-name dirname (macher--workspace-root workspace)))
+            parts))
+     ;; Non-file buffer.
+     (t
+      (push (format "buffer: %s" (buffer-name)) parts)))
     (concat
-     "TASK: Implement the following request using workspace tools.\n\n"
-     "INSTRUCTIONS:\n"
-     "1. Read and understand the implementation request below\n"
-     "2. Use the workspace tools to edit files as needed\n"
-     "3. Create working, complete code that fulfills the request\n\n"
-     source-description
-     (format "\n\nIMPLEMENTATION REQUEST:\n\n%s" input))))
+     "<source>\n" (mapconcat (lambda (s) (concat "  " s)) (reverse parts) "\n") "\n</source>\n")))
+
+(defun macher--implement-prompt (input is-selected)
+  "Generate an implementation prompt for INPUT in the current buffer.
+
+The prompt is slightly different depending on whether the content
+IS-SELECTED (vs being entered manually)."
+  (let ((source-description (macher-source-description)))
+    (concat
+     (when source-description
+       (format "Current focus:\n\n%s\n" source-description))
+     (if is-selected
+         "Implementation request (from selected text):"
+       "Implementation request:")
+     "\n\n" input)))
 
 (defun macher--revise-prompt (input _is-selected &optional patch-buffer)
   "Generate a prompt for revising based on INPUT (revision instructions).
@@ -3326,24 +3395,18 @@ patch buffer) are included in the generated prompt."
           (if patch-buffer
               (with-current-buffer patch-buffer
                 (buffer-substring-no-properties (point-min) (point-max)))
-            ;; Doesn't make sense to call this without a patch.
-            (user-error "No patch buffer found for revision"))))
+            (user-error "No patch buffer found for revision")))
+         (source-description (macher-source-description)))
     (concat
-     "TASK: Revise your previous implementation based on new feedback.\n\n"
-     "WHAT YOU NEED TO DO:\n"
-     "1. Read the revision instructions below (if any)\n"
-     "2. Review your previous patch and its original prompt\n"
-     "3. Understand what needs to be changed or improved\n"
-     "4. Create a NEW implementation that addresses the feedback\n"
-     "5. Use the workspace editing tools to make the changes\n\n"
+     (when source-description
+       (format "Current focus:\n\n%s\n" source-description))
+     (format "Your previous work:\n\n%s" patch-content)
      (if (and input (not (string-empty-p input)))
-         (format "REVISION INSTRUCTIONS:\n%s\n\n" input)
-       "")
-     "\n\n"
-     "==================================\n"
-     "YOUR PREVIOUS WORK (for reference)\n"
-     "==================================\n\n"
-     patch-content)))
+         ":\n\n"
+       ".\n\n")
+     (when (and input (not (string-empty-p input)))
+       (concat input "\n\n"))
+     "Previous work for reference:\n\n" patch-content)))
 
 (defun macher--discuss-prompt (input _is-selected)
   "Generate a prompt for discussion based on INPUT.
@@ -4327,6 +4390,25 @@ associated with the current workspace."
 
 
 ;;; Convenience methods for built-in actions.
+
+;;;###autoload
+(defun macher-source-description (&optional interactive)
+  "Get a description of the source and the user's focus.
+
+This simply evaluates the form (or calls the function) of variable
+`macher-source-description', and returns the result.
+
+If called interactively (which sets INTERACTIVE), also yanks the value
+to the kill ring."
+  (interactive (list "p"))
+  (let ((result
+         (if (functionp macher-source-description)
+             (funcall macher-source-description)
+           (eval macher-source-description))))
+    (when interactive
+      (kill-new result)
+      (message "Source description copied to kill ring"))
+    result))
 
 ;;;###autoload
 (defun macher-implement (&optional instructions callback)

--- a/macher.el
+++ b/macher.el
@@ -503,11 +503,11 @@ This hook runs after the callback provided to `macher-action' (if any)."
 
 ;;;; Context
 
-(defcustom macher-focus-description #'macher--focus-description-default
+(defcustom macher-focus-string #'macher--focus-string-default
   "Function to generate a description of your current location in the code.
 
 This will be evaluated when generating prompts for built-in actions, or
-when calling function `macher-focus-description' directly.  It can be a
+when calling function `macher-focus-string' directly.  It can be a
 sexp form or a function.
 
 The result should be a string describing the user's focus - the file,
@@ -515,9 +515,9 @@ cursor location, selection, etc.  This is included in prompts for
 built-in actions and can be yanked into any conversation to point the
 LLM at a specific place in your code.
 
-By default, this uses `macher--focus-description-default'.
+By default, this uses `macher--focus-string-default'.
 
-Call `macher-focus-description' interactively to yank this value."
+Call `macher-focus-string' interactively to yank this value."
   :type '(choice (function :tag "Function to call") (sexp :tag "Form to evaluate"))
   :group 'macher-actions)
 
@@ -3295,7 +3295,7 @@ otherwise returns (nil . nil)."
           content-pair)))))
 
 ;;; Default Prompt Functions
-(defun macher--focus-description-default ()
+(defun macher--focus-string-default ()
   "Default implementation of focus description.
 
 Returns a string with XML-tagged information about the current buffer,
@@ -3374,10 +3374,10 @@ context text."
 
 The prompt is slightly different depending on whether the content
 IS-SELECTED (vs being entered manually)."
-  (let ((focus-description (macher-focus-description)))
+  (let ((focus-string (macher-focus-string)))
     (concat
-     (when focus-description
-       (concat macher--action-focus-prefix focus-description "\n"))
+     (when focus-string
+       (concat macher--action-focus-prefix focus-string "\n"))
      (if is-selected
          "Implementation request (from selected text):\n\n"
        "Implementation request:\n\n")
@@ -3394,10 +3394,10 @@ patch buffer) are included in the generated prompt."
               (with-current-buffer patch-buffer
                 (buffer-substring-no-properties (point-min) (point-max)))
             (user-error "No patch buffer found for revision")))
-         (focus-description (macher-focus-description)))
+         (focus-string (macher-focus-string)))
     (concat
-     (when focus-description
-       (concat macher--action-focus-prefix focus-description "\n"))
+     (when focus-string
+       (concat macher--action-focus-prefix focus-string "\n"))
      (if (and input (not (string-empty-p input)))
          (format "Revise your previous work based on these instructions:\n\n%s\n\n" input)
        "Revise your previous work.\n\n")
@@ -3407,10 +3407,10 @@ patch buffer) are included in the generated prompt."
   "Generate a prompt for discussion based on INPUT.
 
 Includes the current focus description to provide context."
-  (let ((focus-description (macher-focus-description)))
+  (let ((focus-string (macher-focus-string)))
     (concat
-     (when focus-description
-       (concat macher--action-focus-prefix focus-description "\n"))
+     (when focus-string
+       (concat macher--action-focus-prefix focus-string "\n"))
      input)))
 
 
@@ -4391,22 +4391,22 @@ associated with the current workspace."
 ;;; Convenience methods for built-in actions.
 
 ;;;###autoload
-(defun macher-focus-description (&optional interactive)
+(defun macher-focus-string (&optional interactive)
   "Get a description of your current location in the code.
 
 Evaluates the form (or calls the function) in variable
-`macher-focus-description' and returns the result.
+`macher-focus-string' and returns the result.
 
 If called interactively (which sets INTERACTIVE), yanks the value to
 the kill ring."
   (interactive (list "p"))
   (let ((result
-         (if (functionp macher-focus-description)
-             (funcall macher-focus-description)
-           (eval macher-focus-description))))
+         (if (functionp macher-focus-string)
+             (funcall macher-focus-string)
+           (eval macher-focus-string))))
     (when interactive
       (kill-new result)
-      (message "Source description copied to kill ring"))
+      (message "Focus string copied to kill ring"))
     result))
 
 ;;;###autoload

--- a/macher.el
+++ b/macher.el
@@ -3302,6 +3302,10 @@ Returns a string with XML-tagged information about the current buffer,
 including file path, language, cursor position or selection, and relevant
 context text."
   (let* ((workspace (macher-workspace))
+         (workspace-root
+          (if workspace
+              (macher--workspace-root workspace)
+            default-directory))
          (filename (buffer-file-name))
          (dirname dired-directory)
          (parts nil))
@@ -3315,8 +3319,7 @@ context text."
                  (format-mode-line mode-name))))
              (has-selection (use-region-p)))
         ;; File and language.
-        (push
-         (format "file: %s" (file-relative-name filename (macher--workspace-root workspace))) parts)
+        (push (format "file: %s" (file-relative-name filename workspace-root)) parts)
         (push (format "language: %s" lang) parts)
 
         (if has-selection
@@ -3341,8 +3344,7 @@ context text."
               (push (format "text before cursor:\n%s" text-before-cursor) parts))))))
      ;; Dired directory.
      (dirname
-      (push (format "directory: %s" (file-relative-name dirname (macher--workspace-root workspace)))
-            parts))
+      (push (format "directory: %s" (file-relative-name dirname workspace-root)) parts))
      ;; Non-file buffer.
      (t
       (push (format "buffer: %s" (buffer-name)) parts)))

--- a/macher.el
+++ b/macher.el
@@ -3347,7 +3347,16 @@ context text."
                  (text-before-cursor (buffer-substring-no-properties line-start pos)))
             (push (format "line: %d, column: %d" line col) parts)
             (when (not (string-empty-p text-before-cursor))
-              (push (format "text before cursor:\n%s" text-before-cursor) parts))))))
+              ;; Truncate text-before-cursor to fill-column.
+              (let* ((max-width (or fill-column 70))
+                     (text-length (length text-before-cursor))
+                     (truncated-text
+                      (if (> text-length max-width)
+                          ;; Truncate from the beginning, keeping the end.
+                          (concat
+                           "..." (substring text-before-cursor (- text-length (- max-width 3))))
+                        text-before-cursor)))
+                (push (format "text before cursor:\n%s" truncated-text) parts)))))))
      ;; Dired directory.
      (dirname
       (push (format "directory: %s" (file-relative-name dirname workspace-root)) parts))

--- a/macher.el
+++ b/macher.el
@@ -3367,10 +3367,7 @@ context text."
 
 (defconst macher--action-focus-prefix
   "Current editor context (may or may not be relevant to this request):\n\n"
-  "Prefix for focus description in action prompts.
-
-This clarifies that the focus information is system-provided context
-rather than part of the user's explicit request.")
+  "Prefix for focus description in action prompts.")
 
 (defun macher--implement-prompt (input is-selected)
   "Generate an implementation prompt for INPUT in the current buffer.

--- a/macher.el
+++ b/macher.el
@@ -3354,8 +3354,7 @@ context text."
      ;; Non-file buffer.
      (t
       (push (format "buffer: %s" (buffer-name)) parts)))
-    (concat
-     "<source>\n" (mapconcat #'identity (reverse parts) "\n") "\n</source>\n")))
+    (concat "<source>\n" (mapconcat #'identity (reverse parts) "\n") "\n</source>\n")))
 
 (defun macher--implement-prompt (input is-selected)
   "Generate an implementation prompt for INPUT in the current buffer.

--- a/macher.el
+++ b/macher.el
@@ -3306,9 +3306,15 @@ context text."
           (if workspace
               (macher--workspace-root workspace)
             default-directory))
+         (workspace-name
+          (when workspace
+            (macher--workspace-name workspace)))
          (filename (buffer-file-name))
          (dirname dired-directory)
          (parts nil))
+    ;; Add project name if we have a workspace.
+    (when workspace-name
+      (push (format "project: %s" workspace-name) parts))
     (cond
      ;; Standard file-visiting buffer.
      (filename
@@ -3349,7 +3355,7 @@ context text."
      (t
       (push (format "buffer: %s" (buffer-name)) parts)))
     (concat
-     "<source>\n" (mapconcat (lambda (s) (concat "  " s)) (reverse parts) "\n") "\n</source>\n")))
+     "<source>\n" (mapconcat #'identity (reverse parts) "\n") "\n</source>\n")))
 
 (defun macher--implement-prompt (input is-selected)
   "Generate an implementation prompt for INPUT in the current buffer.

--- a/macher.el
+++ b/macher.el
@@ -3384,8 +3384,7 @@ IS-SELECTED (vs being entered manually)."
      (if is-selected
          "Implementation request (from selected text):\n\n"
        "Implementation request:\n\n")
-     input
-     "\n\nUse the available workspace tools to implement this request.")))
+     input "\n\nUse the available workspace tools to implement this request.")))
 
 (defun macher--revise-prompt (input _is-selected &optional patch-buffer)
   "Generate a prompt for revising based on INPUT (revision instructions).

--- a/macher.el
+++ b/macher.el
@@ -3401,7 +3401,7 @@ patch buffer) are included in the generated prompt."
      (if (and input (not (string-empty-p input)))
          (format "Revise your previous work based on these instructions:\n\n%s\n\n" input)
        "Revise your previous work.\n\n")
-     "Your previous work:\n\n```\n" patch-content "\n```")))
+     "Your previous work:\n\n```diff\n" patch-content "\n```")))
 
 (defun macher--discuss-prompt (input _is-selected)
   "Generate a prompt for discussion based on INPUT.

--- a/macher.el
+++ b/macher.el
@@ -3354,7 +3354,14 @@ context text."
      ;; Non-file buffer.
      (t
       (push (format "buffer: %s" (buffer-name)) parts)))
-    (concat "<source>\n" (mapconcat #'identity (reverse parts) "\n") "\n</source>\n")))
+    (concat "```\n" (mapconcat #'identity (reverse parts) "\n") "\n```\n")))
+
+(defconst macher--action-focus-prefix
+  "Current editor context (may or may not be relevant to this request):\n\n"
+  "Prefix for focus description in action prompts.
+
+This clarifies that the focus information is system-provided context
+rather than part of the user's explicit request.")
 
 (defun macher--implement-prompt (input is-selected)
   "Generate an implementation prompt for INPUT in the current buffer.
@@ -3364,7 +3371,7 @@ IS-SELECTED (vs being entered manually)."
   (let ((focus-description (macher-focus-description)))
     (concat
      (when focus-description
-       (format "Current focus:\n\n%s\n" focus-description))
+       (concat macher--action-focus-prefix focus-description "\n"))
      (if is-selected
          "Implementation request (from selected text):"
        "Implementation request:")
@@ -3384,7 +3391,7 @@ patch buffer) are included in the generated prompt."
          (focus-description (macher-focus-description)))
     (concat
      (when focus-description
-       (format "Current focus:\n\n%s\n" focus-description))
+       (concat macher--action-focus-prefix focus-description "\n"))
      (if (and input (not (string-empty-p input)))
          (format "Revise your previous work based on these instructions:\n\n%s\n\n" input)
        "Revise your previous work.\n\n")
@@ -3397,7 +3404,7 @@ Includes the current focus description to provide context."
   (let ((focus-description (macher-focus-description)))
     (concat
      (when focus-description
-       (format "Current focus:\n\n%s\n" focus-description))
+       (concat macher--action-focus-prefix focus-description "\n"))
      input)))
 
 

--- a/macher.el
+++ b/macher.el
@@ -3378,13 +3378,10 @@ patch buffer) are included in the generated prompt."
     (concat
      (when focus-description
        (format "Current focus:\n\n%s\n" focus-description))
-     (format "Your previous work:\n\n%s" patch-content)
      (if (and input (not (string-empty-p input)))
-         ":\n\n"
-       ".\n\n")
-     (when (and input (not (string-empty-p input)))
-       (concat input "\n\n"))
-     "Previous work for reference:\n\n" patch-content)))
+         (format "Revise your previous work based on these instructions:\n\n%s\n\n" input)
+       "Revise your previous work.\n\n")
+     "Your previous work:\n\n```\n" patch-content "\n```")))
 
 (defun macher--discuss-prompt (input _is-selected)
   "Generate a prompt for discussion based on INPUT.

--- a/macher.el
+++ b/macher.el
@@ -3394,8 +3394,12 @@ patch buffer) are included in the generated prompt."
 (defun macher--discuss-prompt (input _is-selected)
   "Generate a prompt for discussion based on INPUT.
 
-Currently this is just a no-op transformation."
-  input)
+Includes the current focus description to provide context."
+  (let ((focus-description (macher-focus-description)))
+    (concat
+     (when focus-description
+       (format "Current focus:\n\n%s\n" focus-description))
+     input)))
 
 
 (defun macher--patch-prepare-diff (context _fsm callback)

--- a/macher.el
+++ b/macher.el
@@ -3373,9 +3373,10 @@ IS-SELECTED (vs being entered manually)."
      (when focus-description
        (concat macher--action-focus-prefix focus-description "\n"))
      (if is-selected
-         "Implementation request (from selected text):"
-       "Implementation request:")
-     "\n\n" input)))
+         "Implementation request (from selected text):\n\n"
+       "Implementation request:\n\n")
+     input
+     "\n\nUse the available workspace tools to implement this request.")))
 
 (defun macher--revise-prompt (input _is-selected &optional patch-buffer)
   "Generate a prompt for revising based on INPUT (revision instructions).

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -2354,14 +2354,18 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                  ;; Header.
                  "### `%s` %s\n"
                  ;; Full prompt.
-                 "```\nCurrent focus:\n\n%s\n%s\n```\n"
+                 "```\n%s%s\n```\n"
                  ;; Response (may be empty for error/abort).
                  "%s"
                  ;; Trailing prefix only for successful responses.
                  (if include-trailing-prefix
                      "\n### "
                    ""))
-                action request (macher-focus-description) request response)))
+                action request
+                (if (macher-focus-description)
+                    (concat macher--action-focus-prefix (macher-focus-description) "\n")
+                  "")
+                request response)))
      ;; Get the exact expected action buffer contents for org-mode buffers after a single macher action.
      ;; This will need to be updated if the org UI changes.
      (action-buffer-org-content
@@ -2370,14 +2374,18 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                  ;; Org-mode header with action as tag.
                  "*** %s :%s:\n"
                  ;; Prompt block.
-                 ":PROMPT:\nCurrent focus:\n\n%s\n%s\n:END:\n"
+                 ":PROMPT:\n%s%s\n:END:\n"
                  ;; Response (may be empty for error/abort).
                  "%s"
                  ;; Trailing prefix only for successful responses.
                  (if include-trailing-prefix
                      "\n*** "
                    ""))
-                request action (macher-focus-description) request response))))
+                request action
+                (if (macher-focus-description)
+                    (concat macher--action-focus-prefix (macher-focus-description) "\n")
+                  "")
+                request response))))
 
     (before-each
       (setq callback-called nil)

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -2342,7 +2342,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
   (describe "default before-action handler"
     :var*
     (callback-called
-     exit-code fsm callback project-file-buffer
+     exit-code fsm callback project-file-buffer orig-focus-description
      ;; Get the exact expected action buffer contents after a single macher action, with the default
      ;; settings. This will need to be updated if the default UI changes.
      ;;
@@ -2354,14 +2354,14 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                  ;; Header.
                  "### `%s` %s\n"
                  ;; Full prompt.
-                 "```\n%s\n```\n"
+                 "```\nCurrent focus:\n\n%s\n%s\n```\n"
                  ;; Response (may be empty for error/abort).
                  "%s"
                  ;; Trailing prefix only for successful responses.
                  (if include-trailing-prefix
                      "\n### "
                    ""))
-                action request request response)))
+                action request (macher-focus-description) request response)))
      ;; Get the exact expected action buffer contents for org-mode buffers after a single macher action.
      ;; This will need to be updated if the org UI changes.
      (action-buffer-org-content
@@ -2370,14 +2370,14 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                  ;; Org-mode header with action as tag.
                  "*** %s :%s:\n"
                  ;; Prompt block.
-                 ":PROMPT:\n%s\n:END:\n"
+                 ":PROMPT:\nCurrent focus:\n\n%s\n%s\n:END:\n"
                  ;; Response (may be empty for error/abort).
                  "%s"
                  ;; Trailing prefix only for successful responses.
                  (if include-trailing-prefix
                      "\n*** "
                    ""))
-                request action request response))))
+                request action (macher-focus-description) request response))))
 
     (before-each
       (setq callback-called nil)
@@ -2389,6 +2389,9 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                (setq callback-called t)
                (setq exit-code cb-exit-code)
                (setq fsm cb-fsm))))
+      (setq orig-focus-description macher-focus-description)
+      ;; Use a predictable focus description for easier testing.
+      (setq macher-focus-description "[focus]")
 
       (funcall setup-project "macher--after-action")
 
@@ -2398,6 +2401,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
       (setq project-file-buffer (current-buffer)))
 
     (after-each
+      (setq macher-focus-description orig-focus-description)
       (kill-buffer project-file-buffer))
 
     (it "formats prompts/responses for successful requests"

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -2342,7 +2342,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
   (describe "default before-action handler"
     :var*
     (callback-called
-     exit-code fsm callback project-file-buffer orig-focus-description
+     exit-code fsm callback project-file-buffer orig-focus-string
      ;; Get the exact expected action buffer contents after a single macher action, with the default
      ;; settings. This will need to be updated if the default UI changes.
      ;;
@@ -2362,8 +2362,8 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                      "\n### "
                    ""))
                 action request
-                (if (macher-focus-description)
-                    (concat macher--action-focus-prefix (macher-focus-description) "\n")
+                (if (macher-focus-string)
+                    (concat macher--action-focus-prefix (macher-focus-string) "\n")
                   "")
                 request response)))
      ;; Get the exact expected action buffer contents for org-mode buffers after a single macher action.
@@ -2382,8 +2382,8 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                      "\n*** "
                    ""))
                 request action
-                (if (macher-focus-description)
-                    (concat macher--action-focus-prefix (macher-focus-description) "\n")
+                (if (macher-focus-string)
+                    (concat macher--action-focus-prefix (macher-focus-string) "\n")
                   "")
                 request response))))
 
@@ -2397,9 +2397,9 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
                (setq callback-called t)
                (setq exit-code cb-exit-code)
                (setq fsm cb-fsm))))
-      (setq orig-focus-description macher-focus-description)
+      (setq orig-focus-string macher-focus-string)
       ;; Use a predictable focus description for easier testing.
-      (setq macher-focus-description "[focus]")
+      (setq macher-focus-string "[focus]")
 
       (funcall setup-project "macher--after-action")
 
@@ -2409,7 +2409,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
       (setq project-file-buffer (current-buffer)))
 
     (after-each
-      (setq macher-focus-description orig-focus-description)
+      (setq macher-focus-string orig-focus-string)
       (kill-buffer project-file-buffer))
 
     (it "formats prompts/responses for successful requests"

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -4976,12 +4976,12 @@
           (expect result :to-match "file:.*test.js")
           ;; gptel--strip-mode-suffix returns "js" for js-mode.
           (expect result :to-match "language: js")
-          (expect result :to-match "<source>")
+          (expect result :to-match "```")
           ;; Project name should be included.
           (expect result :to-match "project:")
           ;; Content should not be indented (no leading spaces after newline).
-          (expect result :to-match "<source>\nproject:")
-          (expect result :not :to-match "<source>\n  "))))
+          (expect result :to-match "```\nproject:")
+          (expect result :not :to-match "```\n  "))))
 
     (it "includes cursor position when no selection"
       (with-temp-buffer
@@ -5127,7 +5127,7 @@
           (expect prompt :to-match "language: js")
           (expect prompt :to-match "Add error handling")
           (expect prompt :to-match "Implementation request")
-          (expect prompt :to-match "Current focus:")
+          (expect prompt :to-match "Current editor context (may or may not be relevant to this request):")
           ;; Should not have project name when no workspace.
           (expect prompt :not :to-match "project:")))))
 
@@ -5196,8 +5196,8 @@
         (js-mode)
         (setq-local macher--workspace (cons 'file (file-name-directory temp-file)))
         (let ((prompt (macher--revise-prompt "Improve error handling" nil temp-patch-buffer)))
-          (expect prompt :to-match "Current focus:")
-          (expect prompt :to-match "<source>"))))
+          (expect prompt :to-match "Current editor context (may or may not be relevant to this request):")
+          (expect prompt :to-match "```"))))
 
     (it "errors when no patch buffer exists"
       (with-temp-buffer
@@ -5218,7 +5218,7 @@
           (expect prompt :to-match "Revise your previous work")
           (expect prompt :to-match "Fix the indentation")
           (expect prompt :to-match "Your previous work:")
-          (expect prompt :to-match "Current focus:")
+          (expect prompt :to-match "Current editor context (may or may not be relevant to this request):")
           ;; Should not have project name when no workspace.
           (expect prompt :not :to-match "project:")))))
 
@@ -5241,8 +5241,8 @@
         (js-mode)
         (setq-local macher--workspace (cons 'file (file-name-directory temp-file)))
         (let ((prompt (macher--discuss-prompt "What does this code do?" nil)))
-          (expect prompt :to-match "Current focus:")
-          (expect prompt :to-match "<source>")
+          (expect prompt :to-match "Current editor context (may or may not be relevant to this request):")
+          (expect prompt :to-match "```")
           (expect prompt :to-match "project:")
           (expect prompt :to-match "What does this code do?"))))
 
@@ -5252,15 +5252,15 @@
         (find-file temp-file)
         (js-mode)
         (let ((prompt (macher--discuss-prompt "Explain this function" nil)))
-          (expect prompt :to-match "Current focus:")
-          (expect prompt :to-match "<source>")
+          (expect prompt :to-match "Current editor context (may or may not be relevant to this request):")
+          (expect prompt :to-match "```")
           (expect prompt :not :to-match "project:")
           (expect prompt :to-match "Explain this function"))))
 
     (it "handles input when focus description is nil"
       (spy-on 'macher-focus-description :and-return-value nil)
       (let ((prompt (macher--discuss-prompt "General question" nil)))
-        (expect prompt :not :to-match "Current focus:")
+        (expect prompt :not :to-match "Current editor context (may or may not be relevant to this request):")
         (expect prompt :to-equal "General question")))
 
     (it "preserves input text exactly"

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -5163,7 +5163,9 @@
         (js-mode)
         (setq-local macher--workspace (cons 'file (file-name-directory temp-file)))
         (expect (macher--revise-prompt "Fix it" nil nil)
-                :to-throw 'user-error '("No patch buffer found for revision")))))
+                :to-throw
+                'user-error
+                '("No patch buffer found for revision")))))
 
   (describe "macher--resolve-workspace-path"
     :var

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -4950,7 +4950,7 @@
             (expect (length found-handler-states) :to-equal (length expected-handler-states))
             (expect found-handler-states :to-have-same-items-as expected-handler-states))))))
 
-  (describe "macher--focus-description-default"
+  (describe "macher--focus-string-default"
     :var (temp-file temp-dir)
 
     (before-each
@@ -4964,7 +4964,7 @@
 
     (it "returns nil for non-file, non-directory buffers"
       (with-temp-buffer
-        (let ((result (macher--focus-description-default)))
+        (let ((result (macher--focus-string-default)))
           (expect result :to-match "buffer:"))))
 
     (it "includes file path and language for file buffers"
@@ -4972,7 +4972,7 @@
         (find-file temp-file)
         (setq-local macher--workspace (cons 'file temp-dir))
         (js-mode)
-        (let ((result (macher--focus-description-default)))
+        (let ((result (macher--focus-string-default)))
           (expect result :to-match "file:.*test.js")
           ;; gptel--strip-mode-suffix returns "js" for js-mode.
           (expect result :to-match "language: js")
@@ -4991,7 +4991,7 @@
         (goto-char (point-min))
         (forward-line 1)
         (move-to-column 10)
-        (let ((result (macher--focus-description-default)))
+        (let ((result (macher--focus-string-default)))
           (expect result :to-match "line: 2, column: 10"))))
 
     (it "truncates text before cursor when it exceeds fill-column"
@@ -5004,7 +5004,7 @@
         (setq-local fill-column 70)
         (js-mode)
         (goto-char (point-max))
-        (let* ((result (macher--focus-description-default))
+        (let* ((result (macher--focus-string-default))
                ;; Extract the text after "text before cursor:\n".
                (truncated-line
                 (when (string-match "text before cursor:\n\\(.*\\)$" result)
@@ -5028,7 +5028,7 @@
         (setq-local fill-column 70)
         (js-mode)
         (goto-char (point-max))
-        (let ((result (macher--focus-description-default)))
+        (let ((result (macher--focus-string-default)))
           (expect result :to-match "text before cursor:\nshort line")
           ;; Should not have ellipsis.
           (expect result :not :to-match "\\.\\.\\."))))
@@ -5043,7 +5043,7 @@
         (set-mark (point))
         (forward-line 1)
         (activate-mark)
-        (let ((result (macher--focus-description-default)))
+        (let ((result (macher--focus-string-default)))
           (expect result :to-match "selection:")
           (expect result :to-match "function foo"))))
 
@@ -5051,7 +5051,7 @@
       (let ((dired-directory temp-dir))
         (with-temp-buffer
           (setq-local macher--workspace (cons 'file temp-dir))
-          (let ((result (macher--focus-description-default)))
+          (let ((result (macher--focus-string-default)))
             (expect result :to-match "directory:")))))
 
     (it "handles file buffers with no workspace"
@@ -5059,7 +5059,7 @@
       (with-temp-buffer
         (find-file temp-file)
         (js-mode)
-        (let ((result (macher--focus-description-default)))
+        (let ((result (macher--focus-string-default)))
           (expect result :to-match "file:")
           (expect result :to-match "language: js")
           ;; No project name when there's no workspace.
@@ -5069,37 +5069,37 @@
       (spy-on 'macher-workspace :and-return-value nil)
       (let ((dired-directory temp-dir))
         (with-temp-buffer
-          (let ((result (macher--focus-description-default)))
+          (let ((result (macher--focus-string-default)))
             (expect result :to-match "directory:")
             (expect result :not :to-match "project:")))))
 
     (it "handles non-file non-directory buffers with workspace"
       (with-temp-buffer
         (setq-local macher--workspace (cons 'file temp-dir))
-        (let ((result (macher--focus-description-default)))
+        (let ((result (macher--focus-string-default)))
           (expect result :to-match "buffer:")
           (expect result :to-match "project:"))))
 
     (it "handles non-file non-directory buffers without workspace"
       (spy-on 'macher-workspace :and-return-value nil)
       (with-temp-buffer
-        (let ((result (macher--focus-description-default)))
+        (let ((result (macher--focus-string-default)))
           (expect result :to-match "buffer:")
           (expect result :not :to-match "project:")))))
 
-  (describe "macher-focus-description"
+  (describe "macher-focus-string"
     (it "returns result from function when variable is a function"
-      (let ((macher-focus-description (lambda () "test-focus")))
-        (expect (macher-focus-description) :to-equal "test-focus")))
+      (let ((macher-focus-string (lambda () "test-focus")))
+        (expect (macher-focus-string) :to-equal "test-focus")))
 
     (it "evaluates sexp when variable is a sexp"
-      (let ((macher-focus-description '(concat "test" "-" "sexp")))
-        (expect (macher-focus-description) :to-equal "test-sexp")))
+      (let ((macher-focus-string '(concat "test" "-" "sexp")))
+        (expect (macher-focus-string) :to-equal "test-sexp")))
 
     (it "yanks to kill ring when called interactively"
-      (let ((macher-focus-description (lambda () "interactive-test"))
+      (let ((macher-focus-string (lambda () "interactive-test"))
             (kill-ring nil))
-        (macher-focus-description t)
+        (macher-focus-string t)
         (expect (car kill-ring) :to-equal "interactive-test"))))
 
   (describe "macher--implement-prompt"
@@ -5302,7 +5302,7 @@
           (expect prompt :to-match "Explain this function"))))
 
     (it "handles input when focus description is nil"
-      (spy-on 'macher-focus-description :and-return-value nil)
+      (spy-on 'macher-focus-string :and-return-value nil)
       (let ((prompt (macher--discuss-prompt "General question" nil)))
         (expect prompt
                 :not

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -5008,7 +5008,16 @@
         (with-temp-buffer
           (setq-local macher--workspace (cons 'file temp-dir))
           (let ((result (macher--focus-description-default)))
-            (expect result :to-match "directory:"))))))
+            (expect result :to-match "directory:")))))
+
+    (it "handles file buffers with no workspace"
+      (spy-on 'macher-workspace :and-return-value nil)
+      (with-temp-buffer
+        (find-file temp-file)
+        (js-mode)
+        (let ((result (macher--focus-description-default)))
+          (expect result :to-match "file:")
+          (expect result :to-match "language: js")))))
 
   (describe "macher-focus-description"
     (it "returns result from function when variable is a function"

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -5166,7 +5166,8 @@
           (expect prompt :to-match "language: js")
           (expect prompt :to-match "Add error handling")
           (expect prompt :to-match "Implementation request")
-          (expect prompt :to-match "Current editor context (may or may not be relevant to this request):")
+          (expect prompt
+                  :to-match "Current editor context (may or may not be relevant to this request):")
           ;; Should not have project name when no workspace.
           (expect prompt :not :to-match "project:")))))
 
@@ -5235,7 +5236,8 @@
         (js-mode)
         (setq-local macher--workspace (cons 'file (file-name-directory temp-file)))
         (let ((prompt (macher--revise-prompt "Improve error handling" nil temp-patch-buffer)))
-          (expect prompt :to-match "Current editor context (may or may not be relevant to this request):")
+          (expect prompt
+                  :to-match "Current editor context (may or may not be relevant to this request):")
           (expect prompt :to-match "```"))))
 
     (it "errors when no patch buffer exists"
@@ -5257,7 +5259,8 @@
           (expect prompt :to-match "Revise your previous work")
           (expect prompt :to-match "Fix the indentation")
           (expect prompt :to-match "Your previous work:")
-          (expect prompt :to-match "Current editor context (may or may not be relevant to this request):")
+          (expect prompt
+                  :to-match "Current editor context (may or may not be relevant to this request):")
           ;; Should not have project name when no workspace.
           (expect prompt :not :to-match "project:")))))
 
@@ -5280,7 +5283,8 @@
         (js-mode)
         (setq-local macher--workspace (cons 'file (file-name-directory temp-file)))
         (let ((prompt (macher--discuss-prompt "What does this code do?" nil)))
-          (expect prompt :to-match "Current editor context (may or may not be relevant to this request):")
+          (expect prompt
+                  :to-match "Current editor context (may or may not be relevant to this request):")
           (expect prompt :to-match "```")
           (expect prompt :to-match "project:")
           (expect prompt :to-match "What does this code do?"))))
@@ -5291,7 +5295,8 @@
         (find-file temp-file)
         (js-mode)
         (let ((prompt (macher--discuss-prompt "Explain this function" nil)))
-          (expect prompt :to-match "Current editor context (may or may not be relevant to this request):")
+          (expect prompt
+                  :to-match "Current editor context (may or may not be relevant to this request):")
           (expect prompt :to-match "```")
           (expect prompt :not :to-match "project:")
           (expect prompt :to-match "Explain this function"))))
@@ -5299,7 +5304,9 @@
     (it "handles input when focus description is nil"
       (spy-on 'macher-focus-description :and-return-value nil)
       (let ((prompt (macher--discuss-prompt "General question" nil)))
-        (expect prompt :not :to-match "Current editor context (may or may not be relevant to this request):")
+        (expect prompt
+                :not
+                :to-match "Current editor context (may or may not be relevant to this request):")
         (expect prompt :to-equal "General question")))
 
     (it "preserves input text exactly"


### PR DESCRIPTION
Adds an interactive function and customizable variable `macher-focus-string` to provide context about the user's current focus in the editor, e.g. the current file and cursor position. A version of this was previously hardcoded into the `implement` action, but the new implementation includes much better context to direct the LLM to the specific point/region that you're focused on. The focus string is included in all action prompts (implement/revise/discuss), and can be manually yanked with `M-x macher-focus-string`.

The default implementation includes project name, relative file/directory path, language, and cursor position/selection. 