### PR TITLE
chore: add devcontainer config and fix linting/tests

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,2 @@
+FROM node:24-alpine3.23
+RUN apk add bash emacs-nox git grep make patch python3

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,8 +1,7 @@
 FROM node:24-alpine3.23
 RUN apk add bash emacs-nox git grep make patch python3
 
-WORKDIR /opt/macher-deps
+# Warm the npm cache so postCreateCommand is fast.
+WORKDIR /tmp/macher-deps
 COPY package.json package-lock.json ./
-RUN npm ci --ignore-scripts
-
-ENV PATH="/opt/macher-deps/node_modules/.bin:${PATH}"
+RUN npm ci --ignore-scripts && rm -rf /tmp/macher-deps

--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,2 +1,8 @@
 FROM node:24-alpine3.23
 RUN apk add bash emacs-nox git grep make patch python3
+
+WORKDIR /opt/macher-deps
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+ENV PATH="/opt/macher-deps/node_modules/.bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,5 @@
     "dockerfile": "Containerfile",
     "context": ".."
   },
-  "postCreateCommand": "eask install-deps --dev && cp .eask/*/elpa/buttercup-*/buttercup.el .eask/buttercup.el && cp .eask/*/elpa/gptel-*/gptel.el .eask/gptel.el && cp .eask/*/elpa/gptel-*/gptel-ollama.el .eask/gptel-ollama.el"
+  "postCreateCommand": "npm install"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
   "name": "macher",
   "build": {
-    "dockerfile": "Containerfile"
+    "dockerfile": "Containerfile",
+    "context": ".."
   },
-  "postCreateCommand": "npm install"
+  "postCreateCommand": "eask install-deps --dev && cp .eask/*/elpa/buttercup-*/buttercup.el .eask/buttercup.el && cp .eask/*/elpa/gptel-*/gptel.el .eask/gptel.el && cp .eask/*/elpa/gptel-*/gptel-ollama.el .eask/gptel-ollama.el"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "macher",
+  "build": {
+    "dockerfile": "Containerfile"
+  },
+  "postCreateCommand": "npm install"
+}

--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,18 @@ format.check: format.elisp.check format.prettier.check
 PYTHON3 := $(shell which python3)
 
 # Common setup for elisp-autofmt commands. Notes:
+#
 # - We use editorconfig-apply to respect .editorconfig settings (e.g. fill-column).
-# - elisp-autofmt--workaround-make-proc forces use of call-process instead of make-process,
-#   which works around subprocess communication issues in Nix-isolated CI environments.
+#
+# - elisp-autofmt--workaround-make-proc forces use of call-process instead of make-process, which
+#   works around subprocess communication issues in Nix-isolated CI environments.
+#
 # - .eask/*.el provides macro definitions so test files are formatted correctly.
-# - The advice strips harmless "JSON definition:" stderr from elisp-autofmt's Python
-#   subprocess. Without this, null hints in cached defs cause warnings that make
-#   elisp-autofmt-buffer return nil (elisp-autofmt bug, see 4436178).
+#
+# - The advice strips harmless "JSON definition:" stderr from elisp-autofmt's Python subprocess.
+#   Without this, null hints in cached defs cause warnings that make elisp-autofmt-buffer return nil
+#   (might be worth filing an issue upstream, see
+#   https://codeberg.org/ideasman42/emacs-elisp-autofmt/commit/4436178ae0954c5c52d27571e7f2c5c31f5638b2).
 define ELISP_AUTOFMT_SETUP
 --eval "(require 'editorconfig)" \
 --eval "(require 'elisp-autofmt)" \

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ PYTHON3 := $(shell which python3)
 # - elisp-autofmt--workaround-make-proc forces use of call-process instead of make-process,
 #   which works around subprocess communication issues in Nix-isolated CI environments.
 # - .eask/*.el provides macro definitions so test files are formatted correctly.
+# - The advice strips harmless "JSON definition:" stderr from elisp-autofmt's Python
+#   subprocess. Without this, null hints in cached defs cause warnings that make
+#   elisp-autofmt-buffer return nil (elisp-autofmt bug, see 4436178).
 define ELISP_AUTOFMT_SETUP
 --eval "(require 'editorconfig)" \
 --eval "(require 'elisp-autofmt)" \
@@ -70,7 +73,8 @@ define ELISP_AUTOFMT_SETUP
 --eval "(setq elisp-autofmt-python-bin \"$(PYTHON3)\")" \
 -l .eask/buttercup.el \
 -l .eask/gptel.el \
--l .eask/gptel-ollama.el
+-l .eask/gptel-ollama.el \
+--eval "(advice-add 'elisp-autofmt--call-process :filter-return (lambda (r) (let ((stderr (cdr r))) (if (and stderr (string-empty-p (replace-regexp-in-string \"JSON definition:.*\\n?\" \"\" stderr))) (cons (car r) nil) r))))"
 endef
 
 .PHONY: format.elisp

--- a/macher.el
+++ b/macher.el
@@ -1319,7 +1319,7 @@ Returns (file . FILENAME) if the buffer is visiting a file, nil otherwise."
   "Get the project name for PROJECT-ID using project.el."
   (require 'project)
   (if-let ((project (project-current nil project-id)))
-    (project-name project)
+      (project-name project)
     ;; Get the last directory name from the root (trailing slash removed).
     (file-name-nondirectory (directory-file-name project-id))))
 
@@ -2192,12 +2192,12 @@ Signals an error if the directory is not found in the workspace."
          (get-file-content-size
           (file-path) "Get the size of FILE-PATH, considering context modifications."
           (if-let ((entry (assoc (macher--normalize-path file-path) context-contents)))
-            (let* ((contents (cdr entry))
-                   (new-content (cdr contents)))
-              (if new-content
-                  (length new-content)
-                ;; File is deleted in context, so size is 0.
-                0))
+              (let* ((contents (cdr entry))
+                     (new-content (cdr contents)))
+                (if new-content
+                    (length new-content)
+                  ;; File is deleted in context, so size is 0.
+                  0))
             ;; Not in context, get size from disk.
             (if (file-exists-p file-path)
                 (file-attribute-size (file-attributes file-path))
@@ -3562,15 +3562,15 @@ CALLBACK takes no arguments."
     ;; calls) once there's a gptel release that includes
     ;; https://github.com/karthink/gptel/pull/1192.
     (if-let ((parents (plist-get preset-for-gptel :parents)))
-      ;; If the current preset has any parents, apply them and call this function recursively with
-      ;; one parent popped from the front of the list.
-      (let* ((first-parent (car parents))
-             (remaining-parents (cdr parents)))
-        (macher--with-preset
-         first-parent
-         (lambda ()
-           (macher--with-preset
-            (plist-put (copy-sequence preset-for-gptel) :parents remaining-parents) callback))))
+        ;; If the current preset has any parents, apply them and call this function recursively with
+        ;; one parent popped from the front of the list.
+        (let* ((first-parent (car parents))
+               (remaining-parents (cdr parents)))
+          (macher--with-preset
+           first-parent
+           (lambda ()
+             (macher--with-preset
+              (plist-put (copy-sequence preset-for-gptel) :parents remaining-parents) callback))))
       (gptel-with-preset preset-for-gptel (funcall callback)))))
 
 (defun macher--parse-directive (directive)
@@ -3856,20 +3856,20 @@ CALLBACK and FSM are as described in the
                 (setq context-or-t
                       (if (buffer-live-p buffer)
                           (if-let ((workspace (macher-workspace buffer)))
-                            ;; If we found a workspace, perform context initialization.
-                            (let ((context
-                                   (macher--make-context
-                                    :workspace workspace
-                                    :prompt prompt
-                                    :process-request-function process-request-function)))
-                              ;; Store the context on the FSM, so we can look it up e.g. for
-                              ;; processing later.
-                              (setq info (plist-put info :macher--context context))
-                              (setf (gptel-fsm-info fsm) info)
-                              ;; Mark this FSM as the most recent macher request.
-                              (with-current-buffer buffer
-                                (setq macher--fsm-latest fsm))
-                              context)
+                              ;; If we found a workspace, perform context initialization.
+                              (let ((context
+                                     (macher--make-context
+                                      :workspace workspace
+                                      :prompt prompt
+                                      :process-request-function process-request-function)))
+                                ;; Store the context on the FSM, so we can look it up e.g. for
+                                ;; processing later.
+                                (setq info (plist-put info :macher--context context))
+                                (setf (gptel-fsm-info fsm) info)
+                                ;; Mark this FSM as the most recent macher request.
+                                (with-current-buffer buffer
+                                  (setq macher--fsm-latest fsm))
+                                context)
                             ;; Request buffer live but no workspace found.
                             t)
                         ;; Request buffer not live - no workspace can be found.

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -79,6 +79,7 @@ This prevents test flakiness from duplicate callback invocations."
    (original-project-vc-extra-root-markers project-vc-extra-root-markers)
    (original-gptel-backend gptel-backend)
    (original-gptel--known-backends gptel--known-backends)
+   (original-gptel--known-backends-length (length gptel--known-backends))
    (original-gptel-model gptel-model)
    (original-gptel-stream gptel-stream)
    (original-gptel-use-curl gptel-use-curl)
@@ -348,7 +349,8 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
     (gptel-context-remove-all)
     ;; Remove any newly-created backends from the registry.
     (setq gptel--known-backends original-gptel--known-backends)
-    (expect (length gptel--known-backends) :to-be 1)
+    ;; Sanity check that the original list wasn't mutated by reference during the test.
+    (expect (length gptel--known-backends) :to-equal original-gptel--known-backends-length)
     ;; Reset variables that may have changed.
     (setq project-dir nil)
     (setq project-file nil)

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -4801,9 +4801,7 @@
         (let ((found-handler-states nil)
               (expected-handler-states
                (cl-delete-duplicates
-                (mapcan (lambda (row)
-                          (mapcar #'cdr (cdr row)))
-                        gptel-request--transitions))))
+                (mapcan (lambda (row) (mapcar #'cdr (cdr row))) gptel-request--transitions))))
           (dolist (state-handlers (gptel-fsm-handlers fsm))
             (when (member test-handler (cdr state-handlers))
               (push (car state-handlers) found-handler-states)))

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -4796,13 +4796,19 @@
 
         ;; Verify that our handler was actually added to the FSM in the right places.
         (expect (gptel-fsm-handlers fsm) :not :to-equal original-handlers)
-        (let ((found-handler-states nil))
+        ;; Compute expected target states dynamically from the transitions table,
+        ;; so this test doesn't break when gptel adds new FSM states.
+        (let ((found-handler-states nil)
+              (expected-handler-states
+               (cl-delete-duplicates
+                (mapcan (lambda (row)
+                          (mapcar #'cdr (cdr row)))
+                        gptel-request--transitions))))
           (dolist (state-handlers (gptel-fsm-handlers fsm))
             (when (member test-handler (cdr state-handlers))
               (push (car state-handlers) found-handler-states)))
-          (let ((expected-handler-states '(DONE ERRS TOOL TYPE WAIT)))
-            (expect (length found-handler-states) :to-equal (length expected-handler-states))
-            (expect found-handler-states :to-have-same-items-as expected-handler-states))))))
+          (expect (length found-handler-states) :to-equal (length expected-handler-states))
+          (expect found-handler-states :to-have-same-items-as expected-handler-states)))))
 
   (describe "macher--add-termination-handler"
     :var (fsm test-handler handler-calls)


### PR DESCRIPTION
Adds a devcontainer config, with an image containing development dependencies, to make it easier for humans and LLMs to work on macher.

Also fixes some test assertions that had become incorrect after some recent gptel changes affecting the internal variables `gptel--known-backends` and `gptel-request--transitions`. Note there was no breakage in macher itself related to these gptel changes; only in the test assertions.

Also reformats files to account for newer elisp-autofmt behavior, and fixes false negatives in formatting checks.

These changes are only relevant for macher development. No macher functionality is affected.