### PR TITLE
feat: add directory workspace type for non-VCS directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,23 @@ The workspace description can be customized by setting the `macher-context-strin
 
 ### Workspaces
 
-The **workspace** is the set of files macher can read and edit. By default, macher supports:
+The **workspace** is the set of files macher can read and edit.
+
+The workspace is determined by `macher-workspace-functions`. All file operations are restricted to
+the current workspace. By default, macher supports:
 
 - **`project`**: A project.el project
 - **`file`**: A single non-project file
 
-The workspace is determined by `macher-workspace-functions`. All file operations are restricted to
-the current workspace.
+A **`directory`** workspace type is also available for working in arbitrary directories (not managed
+by project.el). It is not enabled by default to avoid accidentally exposing broad directories to the
+LLM. To enable it, you can do something like:
 
-To add custom workspace types, extend `macher-workspace-types-alist` and
+```elisp
+(setq macher-workspace-functions '(macher-workspace-project macher-workspace-directory))
+```
+
+To add custom workspace types, customize `macher-workspace-types-alist` and
 `macher-workspace-functions`.
 
 ### Request lifecycle

--- a/macher.el
+++ b/macher.el
@@ -1802,37 +1802,40 @@ by `macher-workspace'.
 Returns a cons cell (BUFFER . CREATED-P) where BUFFER is the target
 buffer and CREATED-P is t if the buffer was newly created, nil
 otherwise."
-  (let* ((workspace (or workspace (macher-workspace)))
-         (workspace-type (car workspace))
-         (workspace-name (macher--workspace-name workspace))
-         (buffer-type-segment
-          (if buffer-type
-              (format "-%s" buffer-type)
-            ""))
-         (buffer-name
-          (format "*macher%s:%s@%s<%s>*"
-                  buffer-type-segment workspace-type workspace-name
-                  ;; Use a shorter hash in buffer names.
-                  (macher--workspace-hash workspace 4)))
-         target-buffer
-         created-p)
+  (let* ((workspace (or workspace (macher-workspace))))
 
     (unless (consp workspace)
-      (error "Workspace must be a cons cell"))
+      (user-error
+       (concat
+        "No macher workspace found for the current buffer; " "see `macher-workspace-functions'")))
 
-    (setq target-buffer (and buffer-name (get-buffer buffer-name)))
-    (when (and (not target-buffer) create buffer-name)
-      (setq target-buffer (get-buffer-create buffer-name))
-      (setq created-p t)
-      (with-current-buffer target-buffer
-        ;; Track workspace for this buffer.
-        (setq-local macher--workspace workspace)
-        ;; Set the context directory for operations like diff application or 'project.el'
-        ;; lookups.
-        (let ((base-dir (macher--workspace-root workspace)))
-          (setq-local default-directory base-dir))))
-    (when target-buffer
-      (cons target-buffer created-p))))
+    (let* ((workspace-type (car workspace))
+           (workspace-name (macher--workspace-name workspace))
+           (buffer-type-segment
+            (if buffer-type
+                (format "-%s" buffer-type)
+              ""))
+           (buffer-name
+            (format "*macher%s:%s@%s<%s>*"
+                    buffer-type-segment workspace-type workspace-name
+                    ;; Use a shorter hash in buffer names.
+                    (macher--workspace-hash workspace 4)))
+           target-buffer
+           created-p)
+
+      (setq target-buffer (and buffer-name (get-buffer buffer-name)))
+      (when (and (not target-buffer) create buffer-name)
+        (setq target-buffer (get-buffer-create buffer-name))
+        (setq created-p t)
+        (with-current-buffer target-buffer
+          ;; Track workspace for this buffer.
+          (setq-local macher--workspace workspace)
+          ;; Set the context directory for operations like diff application or 'project.el'
+          ;; lookups.
+          (let ((base-dir (macher--workspace-root workspace)))
+            (setq-local default-directory base-dir))))
+      (when target-buffer
+        (cons target-buffer created-p)))))
 
 (defun macher-action-buffer (&optional workspace create)
   "Get the macher action buffer associated with WORKSPACE.

--- a/macher.el
+++ b/macher.el
@@ -260,6 +260,14 @@ This function is used by the default actions in the
 You can use `macher--action-from-region-or-input' if you need to, but
 behavior is subject to change in the future.")
 
+(define-obsolete-function-alias 'macher--project-workspace #'macher-workspace-project "0.6.0"
+  "Renamed to `macher-workspace-project' for a consistent public API.
+All workspace detection functions now use the `macher-workspace-' prefix.")
+
+(define-obsolete-function-alias 'macher--file-workspace #'macher-workspace-file "0.6.0"
+  "Renamed to `macher-workspace-file' for a consistent public API.
+All workspace detection functions now use the `macher-workspace-' prefix.")
+
 (defconst macher--workspace-postfix
   (concat
    "\n\n"
@@ -1132,7 +1140,7 @@ macher tools in your custom presets, etc."
 
 ;;;; Workspace selection and configuration
 
-(defcustom macher-workspace-functions '(macher--project-workspace macher--file-workspace)
+(defcustom macher-workspace-functions '(macher-workspace-project macher-workspace-file)
   "Functions to determine the workspace for the current buffer.
 
 Each function in this list is called with no arguments in the current
@@ -1143,8 +1151,10 @@ Functions should return nil if they cannot determine a workspace for
 the current buffer, allowing other functions in the list to try.
 
 Built-in workspace functions:
-- `macher--project-workspace': Uses project.el to find project workspaces
-- `macher--file-workspace': Falls back to single-file workspaces
+- `macher-workspace-project': Uses project.el to find project workspaces
+- `macher-workspace-file': Falls back to single-file workspaces
+- `macher-workspace-directory': Uses `default-directory' as the
+  workspace root (opt-in, not included in the default value)
 
 The output and patch buffers will be shared among files in the same
 workspace (i.e. same type and ID).
@@ -1167,7 +1177,13 @@ Custom functions should return a cons cell (TYPE . ID) where:
       macher--project-root
       :get-name macher--project-name
       :get-files macher--project-files))
-    (file . (:get-root file-name-directory :get-name file-name-nondirectory :get-files list)))
+    (file . (:get-root file-name-directory :get-name file-name-nondirectory :get-files list))
+    (directory
+     .
+     (:get-root
+      macher--directory-root
+      :get-name macher--directory-name
+      :get-files macher--directory-files)))
   "Alist mapping workspace types to their defining functions.
 
 Each entry is of the form (TYPE . PLIST) where TYPE is a symbol
@@ -1294,18 +1310,38 @@ or is aborted.")
 ;;; Internal Functions
 
 ;; Built-in workspace detection functions
-(defun macher--project-workspace ()
+(defun macher-workspace-project ()
   "Detect project workspace for the current buffer.
 Returns (project . ROOT) if the buffer is in a project, nil otherwise."
   (require 'project)
   (when-let ((project (project-current nil default-directory)))
     (cons 'project (project-root project))))
 
-(defun macher--file-workspace ()
+(defun macher-workspace-file ()
   "Detect file workspace for the current buffer.
 Returns (file . FILENAME) if the buffer is visiting a file, nil otherwise."
   (when-let ((filename (buffer-file-name)))
     (cons 'file filename)))
+
+(defun macher-workspace-directory ()
+  "Detect directory workspace for the current buffer.
+Returns (directory . DIR) using the buffer's `default-directory'.
+
+All files under DIR are exposed to the LLM, including hidden files and
+directories.  This function is NOT included in
+`macher-workspace-functions' by default because it would expose all
+files under `default-directory' to the LLM, which could be intrusive
+for broad directories like the home directory.
+
+To enable, add to `macher-workspace-functions':
+
+  (setq macher-workspace-functions
+        \\='(macher-workspace-project macher-workspace-directory))"
+  (when-let ((dir
+              (and default-directory
+                   (file-directory-p default-directory)
+                   (expand-file-name default-directory))))
+    (cons 'directory dir)))
 
 ;; Built-in workspace type functions
 (defun macher--project-root (project-id)
@@ -1340,6 +1376,24 @@ Returns a list of relative file paths."
               (files (project-files proj)))
     ;; Return files relative to project root.
     (mapcar (lambda (f) (file-relative-name f project-id)) files)))
+
+(defun macher--directory-root (directory-id)
+  "Get the root for DIRECTORY-ID, validating it's a real directory."
+  (unless (and (stringp directory-id)
+               (file-name-absolute-p directory-id)
+               (file-directory-p directory-id))
+    (error "Directory ID '%s' is not a valid directory" directory-id))
+  directory-id)
+
+(defun macher--directory-name (directory-id)
+  "Get a descriptive name for DIRECTORY-ID."
+  (file-name-nondirectory (directory-file-name directory-id)))
+
+(defun macher--directory-files (directory-id)
+  "Get list of files in DIRECTORY-ID recursively.
+Returns a list of relative file paths."
+  (mapcar
+   (lambda (f) (file-relative-name f directory-id)) (directory-files-recursively directory-id "")))
 
 (defun macher-workspace (&optional buffer)
   "Get the workspace information for BUFFER.
@@ -1830,8 +1884,7 @@ otherwise."
         (with-current-buffer target-buffer
           ;; Track workspace for this buffer.
           (setq-local macher--workspace workspace)
-          ;; Set the context directory for operations like diff application or 'project.el'
-          ;; lookups.
+          ;; Set the context directory for operations like diff application or 'project.el' lookups.
           (let ((base-dir (macher--workspace-root workspace)))
             (setq-local default-directory base-dir))))
       (when target-buffer

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -3192,6 +3192,12 @@
           (let ((result (macher--file-workspace)))
             (expect result :to-be nil)))))
 
+    (describe "macher--get-buffer with nil workspace"
+      (it "signals user-error when no workspace can be determined"
+        (with-temp-buffer
+          (let ((macher-workspace-functions nil))
+            (expect (macher--get-buffer nil nil t) :to-throw 'user-error)))))
+
     (describe "macher-workspace"
       (it "returns buffer-local workspace when set"
         (with-temp-buffer

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -3162,11 +3162,11 @@
       (expect project-dir :to-be-truthy)
       (expect file :to-be-truthy))
 
-    (describe "macher--project-workspace"
+    (describe "macher-workspace-project"
       (it "returns project workspace when in a project"
         (with-temp-buffer
           (find-file project-file)
-          (let ((result (macher--project-workspace)))
+          (let ((result (macher-workspace-project)))
             (expect result :to-be-truthy)
             (expect (car result) :to-be 'project)
             (expect (file-truename (directory-file-name (cdr result)))
@@ -3175,24 +3175,122 @@
       (it "returns nil when not in a project"
         (with-temp-buffer
           (find-file file)
-          (let ((result (macher--project-workspace)))
+          (let ((result (macher-workspace-project)))
             (expect result :to-be nil)))))
 
-    (describe "macher--file-workspace"
+    (describe "macher-workspace-file"
       (it "returns file workspace when buffer visits a file"
         (with-temp-buffer
           (find-file file)
-          (let ((result (macher--file-workspace)))
+          (let ((result (macher-workspace-file)))
             (expect result :to-be-truthy)
             (expect (car result) :to-be 'file)
             (expect (cdr result) :to-equal file))))
 
       (it "returns nil when buffer doesn't visit a file"
         (with-temp-buffer
-          (let ((result (macher--file-workspace)))
+          (let ((result (macher-workspace-file)))
             (expect result :to-be nil)))))
 
-    (describe "macher--get-buffer with nil workspace"
+    (describe "macher-workspace-directory"
+      (it "returns directory workspace for any buffer with default-directory"
+        (with-temp-buffer
+          (let ((default-directory (expand-file-name "/tmp/")))
+            (let ((result (macher-workspace-directory)))
+              (expect result :to-be-truthy)
+              (expect (car result) :to-be 'directory)
+              (expect (cdr result) :to-equal (expand-file-name "/tmp/"))))))
+
+      (it "returns nil when default-directory is nil"
+        (with-temp-buffer
+          (let ((default-directory nil))
+            (expect (macher-workspace-directory) :to-be nil))))
+
+      (it "returns nil when default-directory is not a real directory"
+        (with-temp-buffer
+          (let ((default-directory "/nonexistent/path/that/does/not/exist/"))
+            (expect (macher-workspace-directory) :to-be nil))))
+
+      (it "is not used by default, but works when added to `macher-workspace-functions'"
+        (let ((tmp-dir (make-temp-file "macher-dir-ws-" t)))
+          (unwind-protect
+              (with-temp-buffer
+                (let ((default-directory (file-name-as-directory tmp-dir)))
+                  ;; With the default value, no workspace should be detected for a plain directory
+                  ;; buffer (no project, no file).
+                  (let ((macher-workspace-functions (default-value 'macher-workspace-functions)))
+                    (expect (macher-workspace) :to-be nil))
+                  ;; Adding `macher-workspace-directory' to the list makes a directory workspace
+                  ;; detectable.
+                  (let ((macher-workspace-functions
+                         (append
+                          (default-value
+                           'macher-workspace-functions)
+                          (list 'macher-workspace-directory))))
+                    (let ((workspace (macher-workspace)))
+                      (expect (car workspace) :to-be 'directory)
+                      (expect (cdr workspace)
+                              :to-equal (file-name-as-directory (expand-file-name tmp-dir)))))))
+            (delete-directory tmp-dir t)))))
+
+    (describe "macher--directory-root"
+      (it "returns the directory ID for valid directories"
+        (expect (macher--directory-root project-dir) :to-equal project-dir))
+
+      (it "throws error for non-existent directory"
+        (expect (macher--directory-root "/nonexistent/path") :to-throw 'error))
+
+      (it "throws error for non-string input"
+        (expect (macher--directory-root nil) :to-throw 'error)))
+
+    (describe "macher--directory-name"
+      (it "returns the directory basename"
+        (expect (macher--directory-name "/foo/bar/") :to-equal "bar")
+        (expect (macher--directory-name "/foo/bar") :to-equal "bar")))
+
+    (describe "macher--directory-files"
+      (it "returns relative file paths"
+        (let ((files (macher--directory-files project-dir)))
+          (expect files :to-be-truthy)
+          (dolist (f files)
+            (expect (file-name-absolute-p f) :to-be nil))))
+
+      (it "includes files from subdirectories"
+        (let ((files (macher--directory-files project-dir)))
+          (expect (member "subdir/file3.md" files) :to-be-truthy)))
+
+      (it "includes hidden files at the top level"
+        (let ((hidden-file (expand-file-name ".env" project-dir)))
+          (write-region "SECRET=1" nil hidden-file)
+          (let ((files (macher--directory-files project-dir)))
+            (expect (member ".env" files) :to-be-truthy))))
+
+      (it "includes hidden files in subdirectories"
+        (let* ((subdir (expand-file-name "sub" project-dir))
+               (hidden-file (expand-file-name ".env" subdir)))
+          (make-directory subdir)
+          (write-region "SECRET=1" nil hidden-file)
+          (let ((files (macher--directory-files project-dir)))
+            (expect (member "sub/.env" files) :to-be-truthy))))
+
+      (it "includes files inside hidden directories"
+        (let* ((hidden-dir (expand-file-name ".hidden" project-dir))
+               (hidden-file (expand-file-name "secret.txt" hidden-dir)))
+          (make-directory hidden-dir)
+          (write-region "secret" nil hidden-file)
+          (let ((files (macher--directory-files project-dir)))
+            (expect (member ".hidden/secret.txt" files) :to-be-truthy))))
+
+      (it "includes files inside hidden directories nested in normal directories"
+        (let* ((subdir (expand-file-name "sub" project-dir))
+               (nested-hidden-dir (expand-file-name ".cache" subdir))
+               (nested-hidden-file (expand-file-name "data.txt" nested-hidden-dir)))
+          (make-directory nested-hidden-dir t)
+          (write-region "cached" nil nested-hidden-file)
+          (let ((files (macher--directory-files project-dir)))
+            (expect (member "sub/.cache/data.txt" files) :to-be-truthy)))))
+
+    (describe "macher--get-buffer"
       (it "signals user-error when no workspace can be determined"
         (with-temp-buffer
           (let ((macher-workspace-functions nil))


### PR DESCRIPTION
Adds a `directory` workspace type that lets macher work in arbitrary non-project directories. 

`directory` workspaces are disabled by default, as they expose the contents of all files under your buffer's `default-directory` to the LLM, which is potentially invasive when invoked from e.g. a gptel chat in the home directory. To enable them, do something like:

``` elisp
;; Try to resolve the workspace from a project.el project, otherwise fall back to a directory workspace.
(setq macher-workspace-functions '(macher-workspace-project macher-workspace-directory))
```

This PR also adds slightly more user-friendly error behavior when attempting to use macher tools with no available workspace.

Fixes #48.