### PR TITLE
feat: focus action buffer when populating an editable draft

### DIFF
--- a/macher.el
+++ b/macher.el
@@ -1558,11 +1558,17 @@ without needing to put the full path in the buffer name."
 
 This adds local hooks to `macher-before-action-functions' to
 format/insert prompts sent by the user and to display the action buffer
-when actions are performed."
-  ;; Set up the buffer-local hook to insert prompts and headings.
-  (add-hook 'macher-before-action-functions #'macher--before-action-insert-prompt nil t)
+when actions are performed.
+
+The hooks are added with the APPEND flag so they run in the order
+written here: buffer-local `add-hook' prepends by default, which would
+otherwise reverse the run order.  Adding in run order keeps the sequence
+readable and lets the default/org UI append further hooks (scroll,
+focus) that must run after these."
+  ;; Insert the prompt and any headings.
+  (add-hook 'macher-before-action-functions #'macher--before-action-insert-prompt t t)
   ;; Display the action buffer.
-  (add-hook 'macher-before-action-functions #'macher--before-action-display-buffer nil t))
+  (add-hook 'macher-before-action-functions #'macher--before-action-display-buffer t t))
 
 (defun macher--action-buffer-setup-ui ()
   "Set up a slightly more opinionated action buffer UI.
@@ -1576,13 +1582,15 @@ select the action buffer window so the prompt can be edited."
   (setq-local gptel-include-tool-results t)
   ;; Enable gptel-mode for a nice header and LLM interaction feedback.
   (gptel-mode 1)
+  ;; Like `macher--action-buffer-setup-basic', these hooks are appended so they run in the order
+  ;; written, after the insert/display hooks set up there.  The window/point hooks (scroll, focus)
+  ;; depend on the prompt having been inserted and the buffer displayed first.
+  ;;
   ;; Apply the action's preset buffer-locally before each request.
-  (add-hook 'macher-before-action-functions #'macher--before-action-apply-preset nil t)
-  ;; Scroll the action buffer window to the current cursor position.
-  (add-hook 'macher-before-action-functions #'macher--before-action-scroll nil t)
-  ;; For a draft, select the action buffer window so the user can edit the prompt.  Append (rather
-  ;; than the default prepend) so this runs after the insert/display hooks, which set up the window
-  ;; and leave point at the end of the prompt.
+  (add-hook 'macher-before-action-functions #'macher--before-action-apply-preset t t)
+  ;; Scroll the action buffer window to the inserted prompt.
+  (add-hook 'macher-before-action-functions #'macher--before-action-scroll t t)
+  ;; For a draft, select the action buffer window so the user can edit the prompt.
   (add-hook 'macher-before-action-functions #'macher--before-action-focus t t))
 
 (defun macher--before-action-apply-preset (execution)
@@ -1618,10 +1626,10 @@ This is added buffer-locally to `macher-before-action-functions' by
 `macher--action-buffer-setup-ui'."
   (when (macher-action-execution-draft execution)
     (when-let ((win (get-buffer-window (current-buffer) t)))
-      ;; `macher--before-action-insert-prompt' left point at the end of the prompt, but the window
-      ;; was displayed before that, so its stored point is stale.  Sync it before selecting;
-      ;; otherwise `select-window' would restore the stale window point into the buffer, moving
-      ;; point away from the prompt.
+      ;; `macher--before-action-insert-prompt' left point at the end of the prompt, but the window's
+      ;; stored point can be stale (e.g. a reused action buffer window left over from a previous
+      ;; request).  Sync it before selecting; otherwise `select-window' would restore the stale
+      ;; window point into the buffer, moving point away from the prompt.
       (set-window-point win (point))
       (select-window win))))
 

--- a/macher.el
+++ b/macher.el
@@ -248,12 +248,12 @@ This function is used by the default actions in the
            ;; so that `macher-action' populates the action buffer with an editable prompt instead of
            ;; sending immediately.
            ;;
-           ;; NOTE: this is a slight hack. Reading `current-prefix-arg' here ties this helper to the
-           ;; interactive command state rather than receiving the intent explicitly through the
-           ;; action API. It's fine for the current interactive-only workflow, but if this behavior
-           ;; needs to grow (e.g. programmatic control, or per-action customization), it'd be worth
-           ;; threading a well-scoped "edit"/"no-send" signal through `macher-action' and
-           ;; `macher-actions-alist' instead.
+           ;; NOTE: this input-gathering step still reads `current-prefix-arg' directly because it
+           ;; runs in the source buffer, before the `macher-action-execution' exists.  The send and
+           ;; focus decisions in `macher-action' use the execution's `draft' field instead;
+           ;; threading the draft intent all the way into this helper (and the
+           ;; `macher-actions-alist' API)
+           ;; would be a cleaner but larger change.
            (current-prefix-arg
             "")
            ;; Otherwise, prompt the user.
@@ -1315,14 +1315,23 @@ or is aborted.")
 - CONTEXT will be passed as the :context key when calling
   `gptel-request'.  This is a user-defined object that can be read from
   the `gptel-fsm' (state machine) associated with the request.  Functions
-  in `macher-before-action-functions' can modify this field."
+  in `macher-before-action-functions' can modify this field.
+
+- DRAFT, when non-nil, indicates that the request should be populated
+  for manual editing (a draft) rather than sent automatically.
+  `macher-action' sets this from the prefix argument and skips sending
+  the request when it's non-nil.  Functions in
+  `macher-before-action-functions' can read it to adjust their behavior
+  (e.g. the built-in UIs select the action buffer window so the prompt
+  can be edited right away), or modify it to force or suppress sending."
   (action)
   (prompt)
   (preset)
   (summary)
   (buffer)
   (source)
-  (context nil))
+  (context nil)
+  (draft nil))
 
 ;;; Internal Functions
 
@@ -1548,12 +1557,17 @@ without needing to put the full path in the buffer name."
   "Set up basic common behavior for action buffers.
 
 This adds local hooks to `macher-before-action-functions' to
-format/insert prompts sent by the user, and to display the action
-buffer when actions are performed."
+format/insert prompts sent by the user, to display the action buffer
+when actions are performed, and to select its window when populating a
+draft."
   ;; Set up the buffer-local hook to insert prompts and headings.
   (add-hook 'macher-before-action-functions #'macher--before-action-insert-prompt nil t)
   ;; Display the action buffer.
-  (add-hook 'macher-before-action-functions #'macher--before-action-display-buffer nil t))
+  (add-hook 'macher-before-action-functions #'macher--before-action-display-buffer nil t)
+  ;; For a draft, select the action buffer window so the user can edit the prompt.  Append (rather
+  ;; than the default prepend) so this runs after the insert/display hooks, which set up the window
+  ;; and leave point at the end of the prompt.
+  (add-hook 'macher-before-action-functions #'macher--before-action-focus t t))
 
 (defun macher--action-buffer-setup-ui ()
   "Set up a slightly more opinionated action buffer UI.
@@ -1590,6 +1604,20 @@ This is added buffer-locally to `macher-before-action-functions' by
 `macher--action-buffer-setup-ui'."
   (when-let ((win (get-buffer-window (current-buffer))))
     (set-window-point win (point))))
+
+(defun macher--before-action-focus (execution)
+  "Select the action buffer window when EXECUTION is a draft.
+
+For a draft (the `draft' field of EXECUTION is non-nil), the request is
+not sent; the populated prompt is left in the action buffer for manual
+editing.  This selects the buffer's window, if it's displayed, so the
+user can start editing right away.
+
+This is added buffer-locally to `macher-before-action-functions' by
+`macher--action-buffer-setup-basic'."
+  (when (macher-action-execution-draft execution)
+    (when-let ((win (get-buffer-window (current-buffer) t)))
+      (select-window win))))
 
 (defun macher--action-buffer-setup ()
   "Apply the base UI configuration based on `macher-action-buffer-ui'.
@@ -4496,7 +4524,11 @@ implements one possible workflow."
                :preset preset
                :summary summary
                :buffer action-buffer
-               :source source-buffer))
+               :source source-buffer
+               ;; A prefix argument makes the request a draft: populate the buffer but don't send.
+               ;; This is exposed on the execution so `macher-before-action-functions' (and the
+               ;; built-in UIs) can react to it.
+               :draft (and current-prefix-arg t)))
              ;; Create a callback wrapper that includes the action hooks.
              (request-callback
               (lambda (exit-code fsm)
@@ -4535,13 +4567,11 @@ implements one possible workflow."
         ;; It's possible for the before-action hook to change the current buffer, so re-enter the
         ;; shared buffer explicitly.
         ;;
-        ;; With a prefix arg, the before-action hooks above have already populated the action buffer
-        ;; with the prompt; rather than sending, leave it for the user to edit and send manually.
-        (if current-prefix-arg
-            ;; Edit mode: focus the action buffer's window (if it's visible) so the user can start
-            ;; editing the populated prompt right away.
-            (when-let ((win (get-buffer-window action-buffer t)))
-              (select-window win))
+        ;; For a draft, the before-action hooks above have already populated the action buffer with
+        ;; the prompt; rather than sending, leave it for the user to edit and send manually.  The
+        ;; built-in UIs also select the action buffer window in this case - see
+        ;; `macher--before-action-focus'.
+        (unless (macher-action-execution-draft execution)
           (with-current-buffer action-buffer
             (macher--with-preset
              (macher-action-execution-preset execution)

--- a/macher.el
+++ b/macher.el
@@ -1548,17 +1548,12 @@ without needing to put the full path in the buffer name."
   "Set up basic common behavior for action buffers.
 
 This adds local hooks to `macher-before-action-functions' to
-format/insert prompts sent by the user, to display the action buffer
-when actions are performed, and to scroll the buffer so the inserted
-prompt is visible."
+format/insert prompts sent by the user, and to display the action
+buffer when actions are performed."
   ;; Set up the buffer-local hook to insert prompts and headings.
   (add-hook 'macher-before-action-functions #'macher--before-action-insert-prompt nil t)
   ;; Display the action buffer.
-  (add-hook 'macher-before-action-functions #'macher--before-action-display-buffer nil t)
-  ;; Scroll to show the inserted prompt.  Append (rather than the default prepend) so this runs
-  ;; *after* the insert/display hooks above - buffer-local `add-hook' prepends by default, so the
-  ;; most-recently-added function would otherwise run first.
-  (add-hook 'macher-before-action-functions #'macher--before-action-scroll t t))
+  (add-hook 'macher-before-action-functions #'macher--before-action-display-buffer nil t))
 
 (defun macher--action-buffer-setup-ui ()
   "Set up a slightly more opinionated action buffer UI.
@@ -1572,7 +1567,9 @@ buffer-locally."
   ;; Enable gptel-mode for a nice header and LLM interaction feedback.
   (gptel-mode 1)
   ;; Apply the action's preset buffer-locally before each request.
-  (add-hook 'macher-before-action-functions #'macher--before-action-apply-preset nil t))
+  (add-hook 'macher-before-action-functions #'macher--before-action-apply-preset nil t)
+  ;; Scroll the action buffer window to the current cursor position.
+  (add-hook 'macher-before-action-functions #'macher--before-action-scroll nil t))
 
 (defun macher--before-action-apply-preset (execution)
   "Apply the current action's preset buffer-locally.
@@ -1590,7 +1587,7 @@ end of the just-inserted prompt.  This function updates the window to
 show that position.
 
 This is added buffer-locally to `macher-before-action-functions' by
-`macher--action-buffer-setup-basic'."
+`macher--action-buffer-setup-ui'."
   (when-let ((win (get-buffer-window (current-buffer))))
     (set-window-point win (point))))
 

--- a/macher.el
+++ b/macher.el
@@ -417,8 +417,8 @@ predefined \"pre\" function for the `macher-action-buffer-setup-hook'.
 The choices are:
 
 - ='basic' - sets up buffer-local hooks in
-  `macher-before-action-functions' and `macher-after-action-functions'
-  to display the action buffer and insert a nicely-formatted prompt.
+  `macher-before-action-functions' to display the action buffer and
+  insert a nicely-formatted prompt.
 
 - ='default' - like ='basic', but also enables `gptel-mode' and the
   global `gptel-default-mode' (e.g. markdown or org), and ensures tool
@@ -1557,25 +1557,21 @@ without needing to put the full path in the buffer name."
   "Set up basic common behavior for action buffers.
 
 This adds local hooks to `macher-before-action-functions' to
-format/insert prompts sent by the user, to display the action buffer
-when actions are performed, and to select its window when populating a
-draft."
+format/insert prompts sent by the user and to display the action buffer
+when actions are performed."
   ;; Set up the buffer-local hook to insert prompts and headings.
   (add-hook 'macher-before-action-functions #'macher--before-action-insert-prompt nil t)
   ;; Display the action buffer.
-  (add-hook 'macher-before-action-functions #'macher--before-action-display-buffer nil t)
-  ;; For a draft, select the action buffer window so the user can edit the prompt.  Append (rather
-  ;; than the default prepend) so this runs after the insert/display hooks, which set up the window
-  ;; and leave point at the end of the prompt.
-  (add-hook 'macher-before-action-functions #'macher--before-action-focus t t))
+  (add-hook 'macher-before-action-functions #'macher--before-action-display-buffer nil t))
 
 (defun macher--action-buffer-setup-ui ()
   "Set up a slightly more opinionated action buffer UI.
 
 This setup is shared among the symbol `default' and symbol `org' UI
 configurations.  The function enables `gptel-mode', ensures tool results
-are included in output, and sets up a hook to apply the action's preset
-buffer-locally."
+are included in output, sets up a hook to apply the action's preset
+buffer-locally, and sets up hooks to scroll the window and, for a draft,
+select the action buffer window so the prompt can be edited."
   ;; Include tool calls in output.
   (setq-local gptel-include-tool-results t)
   ;; Enable gptel-mode for a nice header and LLM interaction feedback.
@@ -1583,7 +1579,11 @@ buffer-locally."
   ;; Apply the action's preset buffer-locally before each request.
   (add-hook 'macher-before-action-functions #'macher--before-action-apply-preset nil t)
   ;; Scroll the action buffer window to the current cursor position.
-  (add-hook 'macher-before-action-functions #'macher--before-action-scroll nil t))
+  (add-hook 'macher-before-action-functions #'macher--before-action-scroll nil t)
+  ;; For a draft, select the action buffer window so the user can edit the prompt.  Append (rather
+  ;; than the default prepend) so this runs after the insert/display hooks, which set up the window
+  ;; and leave point at the end of the prompt.
+  (add-hook 'macher-before-action-functions #'macher--before-action-focus t t))
 
 (defun macher--before-action-apply-preset (execution)
   "Apply the current action's preset buffer-locally.
@@ -1615,7 +1615,7 @@ places point at the end of the inserted prompt so the user can start
 editing right away.
 
 This is added buffer-locally to `macher-before-action-functions' by
-`macher--action-buffer-setup-basic'."
+`macher--action-buffer-setup-ui'."
   (when (macher-action-execution-draft execution)
     (when-let ((win (get-buffer-window (current-buffer) t)))
       ;; `macher--before-action-insert-prompt' left point at the end of the prompt, but the window
@@ -4473,10 +4473,11 @@ With a prefix argument (e.g. \[universal-argument]), the request is not
 sent.  The `macher-before-action-functions' still run as usual (so, for
 example, the default action buffer UI still populates and displays the
 buffer); the prompt is simply left in the action buffer for you to edit
-and send manually.  If the action buffer is visible, its window is
-selected so you can start editing right away.  In this mode the built-in
-actions skip the minibuffer prompt, using the selected region if there
-is one or an empty request otherwise.
+and send manually.  With the `default' or `org' action buffer UI, the
+action buffer's window is also selected (if visible) so you can start
+editing right away.  In this mode the built-in actions skip the
+minibuffer prompt, using the selected region if there is one or an empty
+request otherwise.
 
 When sending an edited prompt manually, `gptel-send' should \"just
 work\" in an org-mode action buffer with any of the built-in non-nil

--- a/macher.el
+++ b/macher.el
@@ -1610,13 +1610,19 @@ This is added buffer-locally to `macher-before-action-functions' by
 
 For a draft (the `draft' field of EXECUTION is non-nil), the request is
 not sent; the populated prompt is left in the action buffer for manual
-editing.  This selects the buffer's window, if it's displayed, so the
-user can start editing right away.
+editing.  This selects the buffer's window, if it's displayed, and
+places point at the end of the inserted prompt so the user can start
+editing right away.
 
 This is added buffer-locally to `macher-before-action-functions' by
 `macher--action-buffer-setup-basic'."
   (when (macher-action-execution-draft execution)
     (when-let ((win (get-buffer-window (current-buffer) t)))
+      ;; `macher--before-action-insert-prompt' left point at the end of the prompt, but the window
+      ;; was displayed before that, so its stored point is stale.  Sync it before selecting;
+      ;; otherwise `select-window' would restore the stale window point into the buffer, moving
+      ;; point away from the prompt.
+      (set-window-point win (point))
       (select-window win))))
 
 (defun macher--action-buffer-setup ()

--- a/macher.el
+++ b/macher.el
@@ -1548,12 +1548,17 @@ without needing to put the full path in the buffer name."
   "Set up basic common behavior for action buffers.
 
 This adds local hooks to `macher-before-action-functions' to
-format/insert prompts sent by the user, and to display the action
-buffer when actions are performed."
+format/insert prompts sent by the user, to display the action buffer
+when actions are performed, and to scroll the buffer so the inserted
+prompt is visible."
   ;; Set up the buffer-local hook to insert prompts and headings.
   (add-hook 'macher-before-action-functions #'macher--before-action-insert-prompt nil t)
   ;; Display the action buffer.
-  (add-hook 'macher-before-action-functions #'macher--before-action-display-buffer nil t))
+  (add-hook 'macher-before-action-functions #'macher--before-action-display-buffer nil t)
+  ;; Scroll to show the inserted prompt.  Append (rather than the default prepend) so this runs
+  ;; *after* the insert/display hooks above - buffer-local `add-hook' prepends by default, so the
+  ;; most-recently-added function would otherwise run first.
+  (add-hook 'macher-before-action-functions #'macher--before-action-scroll t t))
 
 (defun macher--action-buffer-setup-ui ()
   "Set up a slightly more opinionated action buffer UI.
@@ -1567,9 +1572,7 @@ buffer-locally."
   ;; Enable gptel-mode for a nice header and LLM interaction feedback.
   (gptel-mode 1)
   ;; Apply the action's preset buffer-locally before each request.
-  (add-hook 'macher-before-action-functions #'macher--before-action-apply-preset nil t)
-  ;; Scroll the action buffer window to the current cursor position.
-  (add-hook 'macher-before-action-functions #'macher--before-action-scroll nil t))
+  (add-hook 'macher-before-action-functions #'macher--before-action-apply-preset nil t))
 
 (defun macher--before-action-apply-preset (execution)
   "Apply the current action's preset buffer-locally.
@@ -1587,7 +1590,7 @@ end of the just-inserted prompt.  This function updates the window to
 show that position.
 
 This is added buffer-locally to `macher-before-action-functions' by
-`macher--action-buffer-setup-ui'."
+`macher--action-buffer-setup-basic'."
   (when-let ((win (get-buffer-window (current-buffer))))
     (set-window-point win (point))))
 
@@ -4439,9 +4442,10 @@ With a prefix argument (e.g. \[universal-argument]), the request is not
 sent.  The `macher-before-action-functions' still run as usual (so, for
 example, the default action buffer UI still populates and displays the
 buffer); the prompt is simply left in the action buffer for you to edit
-and send manually.  In this mode the built-in actions skip the
-minibuffer prompt, using the selected region if there is one or an empty
-request otherwise.
+and send manually.  If the action buffer is visible, its window is
+selected so you can start editing right away.  In this mode the built-in
+actions skip the minibuffer prompt, using the selected region if there
+is one or an empty request otherwise.
 
 When sending an edited prompt manually, `gptel-send' should \"just
 work\" in an org-mode action buffer with any of the built-in non-nil
@@ -4535,9 +4539,12 @@ implements one possible workflow."
         ;; shared buffer explicitly.
         ;;
         ;; With a prefix arg, the before-action hooks above have already populated the action buffer
-        ;; with the prompt; leave it there for the user to edit and send manually rather than sending
-        ;; now.
-        (unless current-prefix-arg
+        ;; with the prompt; rather than sending, leave it for the user to edit and send manually.
+        (if current-prefix-arg
+            ;; Edit mode: focus the action buffer's window (if it's visible) so the user can start
+            ;; editing the populated prompt right away.
+            (when-let ((win (get-buffer-window action-buffer t)))
+              (select-window win))
           (with-current-buffer action-buffer
             (macher--with-preset
              (macher-action-execution-preset execution)

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -2525,7 +2525,37 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
               (expect
                buffer-content
                ;; No response text. No trailing prefix.
-               :to-equal (funcall action-buffer-content "Test abort request" "" 'discuss nil))))))))
+               :to-equal (funcall action-buffer-content "Test abort request" "" 'discuss nil)))))))
+
+    (it "populates and focuses the action buffer without sending, with a prefix argument"
+      ;; A backend is set up but should never be hit: in edit mode the request is not sent.
+      (funcall setup-backend '("Response that should never be sent"))
+      (with-current-buffer project-file-buffer
+        ;; Start from a single window so the action buffer is displayed in a fresh one.
+        (delete-other-windows)
+        ;; A prefix argument puts the action into edit mode: populate the buffer but don't send.
+        (let ((current-prefix-arg '(4)))
+          (macher-implement nil callback))
+
+        (let ((action-buffer (macher-action-buffer)))
+          (expect action-buffer :to-be-truthy)
+          ;; In edit mode the request is never sent, so the backend receives nothing and the
+          ;; callback never fires.
+          (expect (funcall received-requests) :to-equal '())
+          (expect callback-called :to-be nil)
+
+          ;; The action buffer's window should be displayed and selected, so the user can start
+          ;; editing the populated prompt right away.
+          (let ((win (get-buffer-window action-buffer t)))
+            (expect win :to-be-truthy)
+            (expect (selected-window) :to-equal win))
+
+          ;; The populated prompt should contain the focus string and the implement instruction.
+          (with-current-buffer action-buffer
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (expect content :to-match (regexp-quote macher--action-focus-prefix))
+              (expect content :to-match "\\[focus\\]")
+              (expect content :to-match "use workspace tools to implement")))))))
 
   (describe "search_in_workspace"
     (before-each

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -2530,35 +2530,42 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
     (it "populates and focuses the action buffer without sending, with a prefix argument"
       ;; A backend is set up but should never be hit: in edit mode the request is not sent.
       (funcall setup-backend '("Response that should never be sent"))
-      (with-current-buffer project-file-buffer
-        ;; Start from a single window so the action buffer is displayed in a fresh one.
-        (delete-other-windows)
-        ;; A prefix argument puts the action into edit mode: populate the buffer but don't send.
-        (let ((current-prefix-arg '(4)))
-          (macher-implement nil callback))
+      ;; `macher--before-action-focus' selects the action buffer's window.  Wrap in
+      ;; `save-window-excursion' to restore the window configuration afterward; otherwise the
+      ;; selected window keeps pointing at the action buffer, and once `after-each' kills the project
+      ;; file buffer the action buffer becomes current, leaking its buffer-local state (workspace,
+      ;; `default-directory', `gptel-system-prompt', etc.) into later specs.
+      (save-window-excursion
+        (with-current-buffer project-file-buffer
+          ;; Start from a single window so the action buffer is displayed in a fresh one.
+          (delete-other-windows)
+          ;; A prefix argument puts the action into edit mode: populate the buffer but don't send.
+          (let ((current-prefix-arg '(4)))
+            (macher-implement nil callback))
 
-        (let ((action-buffer (macher-action-buffer)))
-          (expect action-buffer :to-be-truthy)
-          ;; In edit mode the request is never sent, so the backend receives nothing and the
-          ;; callback never fires.
-          (expect (funcall received-requests) :to-equal '())
-          (expect callback-called :to-be nil)
+          (let ((action-buffer (macher-action-buffer)))
+            (expect action-buffer :to-be-truthy)
+            ;; In edit mode the request is never sent, so the backend receives nothing and the
+            ;; callback never fires.
+            (expect (funcall received-requests) :to-equal '())
+            (expect callback-called :to-be nil)
 
-          ;; The action buffer's window should be displayed and selected, so the user can start
-          ;; editing the populated prompt right away.
-          (let ((win (get-buffer-window action-buffer t)))
-            (expect win :to-be-truthy)
-            (expect (selected-window) :to-equal win))
+            ;; The action buffer's window should be displayed and selected, so the user can start
+            ;; editing the populated prompt right away.
+            (let ((win (get-buffer-window action-buffer t)))
+              (expect win :to-be-truthy)
+              (expect (selected-window) :to-equal win))
 
-          ;; The populated prompt should contain the focus string and the implement instruction.
-          (with-current-buffer action-buffer
-            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
-              (expect content :to-match (regexp-quote macher--action-focus-prefix))
-              (expect content :to-match "\\[focus\\]")
-              (expect content :to-match "use workspace tools to implement"))
-            ;; Point should be left at the end of the inserted prompt, ready for editing.
-            (expect (point) :to-equal (point-max))
-            (expect (window-point (get-buffer-window action-buffer t)) :to-equal (point-max)))))))
+            ;; The populated prompt should contain the focus string and the implement instruction.
+            (with-current-buffer action-buffer
+              (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+                (expect content :to-match (regexp-quote macher--action-focus-prefix))
+                (expect content :to-match "\\[focus\\]")
+                (expect content :to-match "use workspace tools to implement"))
+              ;; Point should be left at the end of the inserted prompt, ready for editing.
+              (expect (point) :to-equal (point-max))
+              (expect (window-point (get-buffer-window action-buffer t))
+                      :to-equal (point-max))))))))
 
   (describe "search_in_workspace"
     (before-each

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -2555,7 +2555,10 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
             (let ((content (buffer-substring-no-properties (point-min) (point-max))))
               (expect content :to-match (regexp-quote macher--action-focus-prefix))
               (expect content :to-match "\\[focus\\]")
-              (expect content :to-match "use workspace tools to implement")))))))
+              (expect content :to-match "use workspace tools to implement"))
+            ;; Point should be left at the end of the inserted prompt, ready for editing.
+            (expect (point) :to-equal (point-max))
+            (expect (window-point (get-buffer-window action-buffer t)) :to-equal (point-max)))))))
 
   (describe "search_in_workspace"
     (before-each

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -4682,6 +4682,24 @@
           ;; Check that gptel-mode is NOT enabled (basic doesn't enable it).
           (expect (bound-and-true-p gptel-mode) :to-be nil))))
 
+    (it "scrolls after inserting and displaying in the basic UI"
+      (let ((macher-action-buffer-ui 'basic))
+        (with-temp-buffer
+          (setq-local macher--workspace '(test . "/tmp/test"))
+          (macher--action-buffer-setup)
+          ;; The scroll hook should be registered for the basic UI.
+          (expect (member #'macher--before-action-scroll macher-before-action-functions)
+                  :to-be-truthy)
+          ;; It must run after the insert and display hooks (before-action functions run in list
+          ;; order, so scroll must appear later in the list to show the just-inserted prompt).
+          (let ((funcs (remq t macher-before-action-functions)))
+            (expect (> (seq-position funcs #'macher--before-action-scroll)
+                       (seq-position funcs #'macher--before-action-insert-prompt))
+                    :to-be-truthy)
+            (expect (> (seq-position funcs #'macher--before-action-scroll)
+                       (seq-position funcs #'macher--before-action-display-buffer))
+                    :to-be-truthy)))))
+
     (it "sets up default UI correctly"
       (let ((macher-action-buffer-ui 'default))
         (with-temp-buffer
@@ -5234,7 +5252,19 @@
           (macher-action 'implement nil "test prompt")
           ;; The before-action functions run even though the request is not sent.
           (expect before-called :to-be-truthy)
-          (expect 'gptel-request :not :to-have-been-called)))))
+          (expect 'gptel-request :not :to-have-been-called))))
+
+    (it "selects the action buffer window when called with a prefix argument"
+      (with-current-buffer project-file-buffer
+        (let ((current-prefix-arg '(4)))
+          ;; Start from a single window so the action buffer gets a fresh one.
+          (delete-other-windows)
+          (macher-action 'implement nil "test prompt")
+          (let ((action-buffer (macher-action-buffer)))
+            ;; The action buffer should be displayed and its window selected, so the user can edit
+            ;; the populated prompt right away.
+            (expect (get-buffer-window action-buffer t) :to-be-truthy)
+            (expect (selected-window) :to-equal (get-buffer-window action-buffer t)))))))
 
   (describe "macher--add-transition-handler"
     :var (fsm test-handler handler-calls)

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -4682,24 +4682,6 @@
           ;; Check that gptel-mode is NOT enabled (basic doesn't enable it).
           (expect (bound-and-true-p gptel-mode) :to-be nil))))
 
-    (it "scrolls after inserting and displaying in the basic UI"
-      (let ((macher-action-buffer-ui 'basic))
-        (with-temp-buffer
-          (setq-local macher--workspace '(test . "/tmp/test"))
-          (macher--action-buffer-setup)
-          ;; The scroll hook should be registered for the basic UI.
-          (expect (member #'macher--before-action-scroll macher-before-action-functions)
-                  :to-be-truthy)
-          ;; It must run after the insert and display hooks (before-action functions run in list
-          ;; order, so scroll must appear later in the list to show the just-inserted prompt).
-          (let ((funcs (remq t macher-before-action-functions)))
-            (expect (> (seq-position funcs #'macher--before-action-scroll)
-                       (seq-position funcs #'macher--before-action-insert-prompt))
-                    :to-be-truthy)
-            (expect (> (seq-position funcs #'macher--before-action-scroll)
-                       (seq-position funcs #'macher--before-action-display-buffer))
-                    :to-be-truthy)))))
-
     (it "sets up default UI correctly"
       (let ((macher-action-buffer-ui 'default))
         (with-temp-buffer

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -4706,6 +4706,17 @@
           (expect (member #'macher--before-action-insert-prompt macher-before-action-functions)
                   :to-be-truthy))))
 
+    (it "registers the focus hook in all built-in UIs"
+      ;; Focusing is paired with displaying the buffer, so every built-in UI (including basic) sets
+      ;; it up.
+      (dolist (ui '(basic default org))
+        (let ((macher-action-buffer-ui ui))
+          (with-temp-buffer
+            (setq-local macher--workspace '(test . "/tmp/test"))
+            (macher--action-buffer-setup)
+            (expect (member #'macher--before-action-focus macher-before-action-functions)
+                    :to-be-truthy)))))
+
     (it "performs no setup when UI is nil"
       (let ((macher-action-buffer-ui nil))
         (with-temp-buffer
@@ -5127,6 +5138,44 @@
         ;; Should not error when there's no window.
         (expect (macher--before-action-scroll nil) :not :to-throw))))
 
+  (describe "macher--before-action-focus"
+    (it "selects the buffer's window when the execution is a draft"
+      (let ((buf (generate-new-buffer "*test-focus*")))
+        (unwind-protect
+            (progn
+              (delete-other-windows)
+              (let ((win (display-buffer buf))
+                    (execution (macher--make-action-execution :draft t)))
+                (expect win :to-be-truthy)
+                ;; `display-buffer' does not select the new window, so it starts unselected.
+                (expect (selected-window) :not :to-equal win)
+                (with-current-buffer buf
+                  (macher--before-action-focus execution))
+                ;; A draft selects the action buffer's window.
+                (expect (selected-window) :to-equal win)))
+          (kill-buffer buf))))
+
+    (it "does nothing when the execution is not a draft"
+      (let ((buf (generate-new-buffer "*test-focus*")))
+        (unwind-protect
+            (progn
+              (delete-other-windows)
+              (let ((original-window (selected-window))
+                    (win (display-buffer buf))
+                    (execution (macher--make-action-execution :draft nil)))
+                (expect win :to-be-truthy)
+                (with-current-buffer buf
+                  (macher--before-action-focus execution))
+                ;; Not a draft: the selection is left untouched.
+                (expect (selected-window) :to-equal original-window)
+                (expect (selected-window) :not :to-equal win)))
+          (kill-buffer buf))))
+
+    (it "is a no-op for a draft when the buffer has no window"
+      (with-temp-buffer
+        (let ((execution (macher--make-action-execution :draft t)))
+          (expect (macher--before-action-focus execution) :not :to-throw)))))
+
   (describe "macher-action"
     :var ((original-action-buffer-setup-hook macher-action-buffer-setup-hook) project-file-buffer)
 
@@ -5225,6 +5274,32 @@
           (expect (with-current-buffer action-buffer
                     (buffer-string))
                   :to-match "test prompt"))))
+
+    (it "exposes draft mode on the execution when called with a prefix argument"
+      (with-current-buffer project-file-buffer
+        (let* ((captured-draft 'unset)
+               (macher-before-action-functions
+                (list
+                 (lambda (execution)
+                   (setq captured-draft (macher-action-execution-draft execution)))))
+               (current-prefix-arg '(4)))
+          (macher-action 'implement nil "test prompt")
+          ;; Before-action functions can see that this is a draft request.
+          (expect captured-draft :to-be-truthy)
+          (expect 'gptel-request :not :to-have-been-called))))
+
+    (it "does not mark the execution as a draft without a prefix argument"
+      (with-current-buffer project-file-buffer
+        (let* ((captured-draft 'unset)
+               (macher-before-action-functions
+                (list
+                 (lambda (execution)
+                   (setq captured-draft (macher-action-execution-draft execution)))))
+               (current-prefix-arg nil))
+          (macher-action 'implement nil "test prompt")
+          ;; Not a draft: the field is nil and the request is sent.
+          (expect captured-draft :to-be nil)
+          (expect 'gptel-request :to-have-been-called))))
 
     (it "still runs the before-action functions when called with a prefix argument"
       (with-current-buffer project-file-buffer

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -4706,16 +4706,24 @@
           (expect (member #'macher--before-action-insert-prompt macher-before-action-functions)
                   :to-be-truthy))))
 
-    (it "registers the focus hook in all built-in UIs"
-      ;; Focusing is paired with displaying the buffer, so every built-in UI (including basic) sets
-      ;; it up.
-      (dolist (ui '(basic default org))
+    (it "registers the focus hook only in the default and org UIs"
+      ;; Selecting the action buffer window is an opinionated behavior, so it lives with the other
+      ;; default/org UI setup rather than the basic UI.
+      (dolist (ui '(default org))
         (let ((macher-action-buffer-ui ui))
           (with-temp-buffer
             (setq-local macher--workspace '(test . "/tmp/test"))
             (macher--action-buffer-setup)
             (expect (member #'macher--before-action-focus macher-before-action-functions)
-                    :to-be-truthy)))))
+                    :to-be-truthy))))
+      ;; The basic UI is intentionally passive: it displays the buffer but does not select its
+      ;; window.
+      (let ((macher-action-buffer-ui 'basic))
+        (with-temp-buffer
+          (setq-local macher--workspace '(test . "/tmp/test"))
+          (macher--action-buffer-setup)
+          (expect (member #'macher--before-action-focus macher-before-action-functions)
+                  :to-be nil))))
 
     (it "performs no setup when UI is nil"
       (let ((macher-action-buffer-ui nil))

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -5174,7 +5174,31 @@
     (it "is a no-op for a draft when the buffer has no window"
       (with-temp-buffer
         (let ((execution (macher--make-action-execution :draft t)))
-          (expect (macher--before-action-focus execution) :not :to-throw)))))
+          (expect (macher--before-action-focus execution) :not :to-throw))))
+
+    (it "leaves point at the end of the prompt after selecting the window"
+      (let ((buf (generate-new-buffer "*test-focus*")))
+        (unwind-protect
+            (progn
+              (delete-other-windows)
+              (with-current-buffer buf
+                (dotimes (_ 50)
+                  (insert "filler line\n")))
+              ;; Display the buffer before "inserting the prompt", so the window's stored point is
+              ;; stale (at the top), mirroring the real before-action ordering.
+              (let ((win (display-buffer buf))
+                    (execution (macher--make-action-execution :draft t)))
+                (set-window-point win (point-min))
+                (with-current-buffer buf
+                  ;; Move point to the end, as `macher--before-action-insert-prompt' would.
+                  (goto-char (point-max))
+                  (let ((prompt-end (point)))
+                    (macher--before-action-focus execution)
+                    ;; Point should remain at the end of the prompt, not jump to the stale window
+                    ;; point.
+                    (expect (point) :to-equal prompt-end)
+                    (expect (window-point win) :to-equal prompt-end)))))
+          (kill-buffer buf)))))
 
   (describe "macher-action"
     :var ((original-action-buffer-setup-hook macher-action-buffer-setup-hook) project-file-buffer)


### PR DESCRIPTION
Follow-up to #64, which introduced the prefix-argument "edit mode" for `macher-action` (and its wrappers `macher-implement`, `macher-revise`, `macher-discuss`): with a prefix, the action buffer is populated with the prompt but the request is not sent, so the prompt can be edited and sent manually.

This improves the ergonomics of that workflow and cleans up its plumbing:

- When inserting editable action text (and as long as you're using one of the built-in `macher-action-buffer-ui`s), the action buffer's window is now selected (if displayed), with point left at the end of the inserted prompt, so you can start editing right away. 

- The send/focus decision is now driven by an explicit `draft` field on the `macher-action-execution` struct rather than reading `current-prefix-arg` deep in the request logic. `macher-action` derives the field from the prefix argument and skips sending when it's set. The field is visible to `macher-before-action-functions`, which can read it to adjust their behavior, or modify it to force or suppress sending.
