### PR TITLE
ci: fix warnings and occasional rate errors in github actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,12 +22,12 @@ runs:
 
     # Install python for elisp-autofmt invocations.
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: "lts/*"
         cache: npm

--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       # Allow filing issues if the run fails.
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
       - name: Verify the integrity of installed dependencies

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -119,8 +119,31 @@ jobs:
           ollama pull "$MODEL_NAME"
 
       - name: Run tests
+        uses: nick-fields/retry@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Disable GitHub Models in tests if the API is not available.
           MACHER_DISABLE_GITHUB_MODELS: ${{ steps.check-github-models.outputs.available == 'false' && '1' || '' }}
-        run: make test
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 60
+          # Only retry on transient rate-limiting from the GitHub Models API. The
+          # command below runs `make test` and inspects the output for an HTTP 429;
+          # a genuine test failure exits with a different code and fails the job
+          # immediately rather than being retried. `retry_on_exit_code` makes the
+          # retry action only re-run for that specific exit code (75).
+          retry_on_exit_code: 75
+          command: |
+            set +e
+            set -o pipefail
+            make test 2>&1 | tee /tmp/macher-test-output.log
+            status=${PIPESTATUS[0]}
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            if grep -Eq "HTTP/[0-9.]+ 429" /tmp/macher-test-output.log; then
+              echo "::warning::Test failure involved an HTTP 429 (rate limit); retrying."
+              exit 75
+            fi
+            exit "$status"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
 
       - name: Check formatting
@@ -50,7 +50,7 @@ jobs:
         emacs-version: ${{ fromJson(needs.prepare.outputs.emacs-versions) }}
     name: compile (emacs ${{ matrix.emacs-version }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
         with:
           emacs-version: ${{ matrix.emacs-version }}
@@ -70,7 +70,7 @@ jobs:
       contents: read
       models: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
         with:
           emacs-version: ${{ matrix.emacs-version }}
@@ -101,13 +101,13 @@ jobs:
       # Note this also starts the ollama server.
       - name: Install Ollama
         if: steps.check-github-models.outputs.available == 'false'
-        uses: ai-action/setup-ollama@v1
+        uses: ai-action/setup-ollama@v2
 
       # See https://github.com/ai-action/setup-ollama/issues/40.
       - name: Cache Ollama
         if: steps.check-github-models.outputs.available == 'false'
         id: cache-artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.ollama
           key: ${{ runner.os }}-ollama

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -92,12 +92,15 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 60
-          # Only retry on transient rate-limiting from the GitHub Models API.
-          # The command below runs `make test` and inspects the output for an
-          # HTTP 429; a genuine test failure exits with a different code and
-          # fails the job immediately rather than being retried.
-          # `retry_on_exit_code` makes the retry action only re-run for that
-          # specific exit code (75).
+          # The command below runs `make test` and inspects the output:
+          # - On an HTTP 429 (rate limiting), it exits 75 to trigger a retry.
+          # - On success, it checks for skipped tests and fails the job if
+          #   any are found (buttercup prints "Running X out of Y specs"
+          #   when there are pending tests, vs "Running X specs." when all
+          #   run). This catches misconfiguration where tests are silently
+          #   skipped due to missing env vars.
+          # `retry_on_exit_code` makes the retry action only re-run for
+          # exit code 75; any other non-zero code fails immediately.
           retry_on_exit_code: 75
           command: |
             set +e
@@ -105,6 +108,10 @@ jobs:
             make test 2>&1 | tee /tmp/macher-test-output.log
             status=${PIPESTATUS[0]}
             if [ "$status" -eq 0 ]; then
+              if grep -Eq '^Running [0-9]+ out of [0-9]+ specs' /tmp/macher-test-output.log; then
+                echo "::error::Some tests were skipped (pending). All tests must run in CI."
+                exit 1
+              fi
               exit 0
             fi
             if grep -Eq "HTTP/[0-9.]+ 429" /tmp/macher-test-output.log; then

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -94,11 +94,11 @@ jobs:
           retry_wait_seconds: 60
           # The command below runs `make test` and inspects the output:
           # - On an HTTP 429 (rate limiting), it exits 75 to trigger a retry.
-          # - On success, it checks for skipped tests and fails the job if
-          #   any are found (buttercup prints "Running X out of Y specs"
-          #   when there are pending tests, vs "Running X specs." when all
-          #   run). This catches misconfiguration where tests are silently
-          #   skipped due to missing env vars.
+          # - On success, it checks for the skip message emitted by the
+          #   `assume' call in tests/test-functional.el, which fires when the
+          #   test endpoint isn't configured. Buttercup still exits 0 in that
+          #   case, so without this check a misconfigured CI run would pass
+          #   with the functional tests silently skipped.
           # `retry_on_exit_code` makes the retry action only re-run for
           # exit code 75; any other non-zero code fails immediately.
           retry_on_exit_code: 75
@@ -108,8 +108,8 @@ jobs:
             make test 2>&1 | tee /tmp/macher-test-output.log
             status=${PIPESTATUS[0]}
             if [ "$status" -eq 0 ]; then
-              if grep -Eq '^Running [0-9]+ out of [0-9]+ specs' /tmp/macher-test-output.log; then
-                echo "::error::Some tests were skipped (pending). All tests must run in CI."
+              if grep -qF 'MACHER_TEST_OPENAI_BASE_URL not set' /tmp/macher-test-output.log; then
+                echo "::error::Functional tests were skipped; the test endpoint is not configured."
                 exit 1
               fi
               exit 0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,70 +69,32 @@ jobs:
     permissions:
       contents: read
       models: read
+    # Serialize test jobs so only one is hitting the GitHub Models API at a
+    # time. The matrix legs and concurrent pushes can otherwise pile up and
+    # trigger rate limiting (HTTP 429).
+    concurrency:
+      group: test-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
         with:
           emacs-version: ${{ matrix.emacs-version }}
 
-      # If GitHub Models are down due to rate limiting or service issues, functional tests can fall
-      # back to using ollama, it'll just be rather slow.
-      - name: Check GitHub Models availability
-        id: check-github-models
-        continue-on-error: true
-        run: |
-          # Test if GitHub Models API is accessible by sending a minimal request.
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -X POST \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"messages":[{"role":"user","content":"test"}],"model":"gpt-4o-mini","max_tokens":1}' \
-            "https://models.github.ai/inference/chat/completions")
-
-          if [ "$HTTP_CODE" = "429" ] || [ "$HTTP_CODE" = "503" ] || [ "$HTTP_CODE" = "500" ]; then
-            echo "GitHub Models API returned $HTTP_CODE, will fall back to Ollama"
-            echo "available=false" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "GitHub Models API is available (HTTP $HTTP_CODE)"
-            echo "available=true" >> $GITHUB_OUTPUT
-          fi
-
-      # Note this also starts the ollama server.
-      - name: Install Ollama
-        if: steps.check-github-models.outputs.available == 'false'
-        uses: ai-action/setup-ollama@v2
-
-      # See https://github.com/ai-action/setup-ollama/issues/40.
-      - name: Cache Ollama
-        if: steps.check-github-models.outputs.available == 'false'
-        id: cache-artifacts
-        uses: actions/cache@v6
-        with:
-          path: ~/.ollama
-          key: ${{ runner.os }}-ollama
-
-      - name: Pull Ollama model
-        if: steps.check-github-models.outputs.available == 'false'
-        run: |
-          MODEL_NAME=$(grep -o 'ollama-model "[^"]*"' tests/test-functional.el | cut -d'"' -f2)
-          ollama pull "$MODEL_NAME"
-
       - name: Run tests
         uses: nick-fields/retry@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Disable GitHub Models in tests if the API is not available.
-          MACHER_DISABLE_GITHUB_MODELS: ${{ steps.check-github-models.outputs.available == 'false' && '1' || '' }}
         with:
           timeout_minutes: 10
           max_attempts: 3
           retry_wait_seconds: 60
-          # Only retry on transient rate-limiting from the GitHub Models API. The
-          # command below runs `make test` and inspects the output for an HTTP 429;
-          # a genuine test failure exits with a different code and fails the job
-          # immediately rather than being retried. `retry_on_exit_code` makes the
-          # retry action only re-run for that specific exit code (75).
+          # Only retry on transient rate-limiting from the GitHub Models API.
+          # The command below runs `make test` and inspects the output for an
+          # HTTP 429; a genuine test failure exits with a different code and
+          # fails the job immediately rather than being retried.
+          # `retry_on_exit_code` makes the retry action only re-run for that
+          # specific exit code (75).
           retry_on_exit_code: 75
           command: |
             set +e

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -85,6 +85,9 @@ jobs:
         uses: nick-fields/retry@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MACHER_TEST_OPENAI_BASE_URL: https://models.github.ai/inference
+          MACHER_TEST_OPENAI_KEY: ${{ secrets.GITHUB_TOKEN }}
+          MACHER_TEST_OPENAI_MODEL: gpt-4o-mini
         with:
           timeout_minutes: 10
           max_attempts: 3

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /.eask/
 /node_modules/
 
+/Makefile.local
+
 /.github/terraform/.terraform/
 /.github/terraform/terraform.tfstate
 /.github/terraform/terraform.tfstate.backup

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ AGG := agg
 ASCIINEMA := asciinema
 FFMPEG := ffmpeg
 
+# Optional local overrides (e.g. test endpoint configuration). Gitignored.
+-include Makefile.local
+
 # Note this also installs eask dependencies via the package's postinstall script.
 $(EASK) $(PRETTIER) .eask: package.json package-lock.json Eask
 	"$(NPM)" install

--- a/Makefile.local.example
+++ b/Makefile.local.example
@@ -1,5 +1,7 @@
-# Copy to Makefile.local and edit. Gitignored, auto-included by the Makefile.
+# -*- mode: makefile -*-
 #
+# Copy this file to Makefile.local and edit for your setup. Auto-included by the Makefile.
+
 # Set these to point functional tests at an OpenAI-compatible API endpoint.
 # The base URL is everything up to (but not including) /chat/completions.
 export MACHER_TEST_OPENAI_BASE_URL := http://localhost:51517/v1

--- a/Makefile.local.example
+++ b/Makefile.local.example
@@ -1,0 +1,7 @@
+# Copy to Makefile.local and edit. Gitignored, auto-included by the Makefile.
+#
+# Set these to point functional tests at an OpenAI-compatible API endpoint.
+# The base URL is everything up to (but not including) /chat/completions.
+export MACHER_TEST_OPENAI_BASE_URL := http://localhost:51517/v1
+export MACHER_TEST_OPENAI_KEY := dummy
+export MACHER_TEST_OPENAI_MODEL := gpt-4o-mini

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "eask exec buttercup --stale-file-error tests/",
     "//": "postinstall copies package files so elisp-autofmt can read macro definitions even when packages aren't installed in the user's Emacs",
-    "postinstall": "eask install-deps --dev && cp .eask/*/elpa/buttercup-*/buttercup.el .eask/buttercup.el && cp .eask/*/elpa/gptel-*/gptel.el .eask/gptel.el && cp .eask/*/elpa/gptel-*/gptel-ollama.el .eask/gptel-ollama.el"
+    "postinstall": "eask install-deps --dev && cp $(ls .eask/*/elpa/buttercup-*/buttercup.el | head -1) .eask/buttercup.el && cp $(ls .eask/*/elpa/gptel-*/gptel.el | head -1) .eask/gptel.el && cp $(ls .eask/*/elpa/gptel-*/gptel-ollama.el | head -1) .eask/gptel-ollama.el"
   },
   "devDependencies": {
     "@emacs-eask/cli": "^0.11.1",

--- a/tests/test-functional.el
+++ b/tests/test-functional.el
@@ -12,7 +12,7 @@
 ;;   MACHER_TEST_OPENAI_MODEL to configure an OpenAI-compatible endpoint.
 ;;   If MACHER_TEST_OPENAI_BASE_URL is unset, all functional tests are
 ;;   skipped (registered but marked pending via `assume').
-;; - In CI, these are set in the workflow file. Locally, they can be set
+;; - In CI, these are set in the workflow file.  Locally, they can be set
 ;;   in a gitignored Makefile.local that the Makefile auto-includes.
 
 ;;; Code:
@@ -239,8 +239,7 @@ CALLBACK-TEST is a function that verifies the result."
     ;; Skip all functional tests if no test endpoint is configured. This
     ;; registers the specs but marks them as pending so they show up in
     ;; the test output without running.
-    (assume test-base-url
-            "MACHER_TEST_OPENAI_BASE_URL not set; skipping functional tests")
+    (assume test-base-url "MACHER_TEST_OPENAI_BASE_URL not set; skipping functional tests")
 
     ;; Allow project.el to detect projects with .project marker file in the root.
     (setq project-vc-extra-root-markers '(".project"))
@@ -253,16 +252,19 @@ CALLBACK-TEST is a function that verifies the result."
     ;; Configure gptel to use an OpenAI-compatible test endpoint. The base URL is
     ;; everything up to (but not including) /chat/completions; we append that suffix
     ;; and parse the result into protocol, host, and endpoint for `gptel-make-openai'.
-    (let* ((full-url (concat (string-trim-right test-base-url "/")
-                             "/chat/completions"))
+    (let* ((full-url (concat (string-trim-right test-base-url "/") "/chat/completions"))
            (parsed (url-generic-parse-url full-url))
            (protocol (url-type parsed))
            (host (url-host parsed))
            (port (url-port parsed))
-           (default-port (if (string= protocol "https") 443 80))
-           (host-str (if (and port (/= port default-port))
-                         (format "%s:%d" host port)
-                       host))
+           (default-port
+            (if (string= protocol "https")
+                443
+              80))
+           (host-str
+            (if (and port (/= port default-port))
+                (format "%s:%d" host port)
+              host))
            (endpoint (url-filename parsed))
            (model (or test-model "gpt-4o-mini"))
            (api-key (or test-api-key "dummy")))

--- a/tests/test-functional.el
+++ b/tests/test-functional.el
@@ -8,17 +8,21 @@
 ;; to catch issues in the general end-to-end implementation workflow.
 ;;
 ;; Backend selection:
-;; - In CI (GITHUB_ACTIONS env var set): Uses GitHub Models API with gpt-4o-mini.
-;; - Locally: Uses Ollama with a local model (works offline).
+;; - Set MACHER_TEST_OPENAI_BASE_URL, MACHER_TEST_OPENAI_KEY, and
+;;   MACHER_TEST_OPENAI_MODEL to configure an OpenAI-compatible endpoint.
+;;   If MACHER_TEST_OPENAI_BASE_URL is unset, all functional tests are
+;;   skipped (registered but marked pending via `assume').
+;; - In CI, these are set in the workflow file. Locally, they can be set
+;;   in a gitignored Makefile.local that the Makefile auto-includes.
 
 ;;; Code:
 
 (require 'buttercup)
 (require 'macher)
 (require 'gptel)
-(require 'gptel-ollama)
 (require 'gptel-openai)
 (require 'project)
+(require 'url)
 
 ;; Uncomment for debugging output.
 ;;
@@ -52,23 +56,13 @@
 (describe "functional tests"
   :var*
   (
-   ;; Whether to use GitHub Models API (in CI) or Ollama (locally).
-   ;; Can be disabled via MACHER_DISABLE_GITHUB_MODELS env var if GitHub Models API is unavailable.
-   (use-github-models
-    (and (getenv "GITHUB_ACTIONS")
-         (let ((disable-var (getenv "MACHER_DISABLE_GITHUB_MODELS")))
-           (not (and disable-var (not (string-empty-p disable-var)))))))
-
-   ;; GitHub Models configuration.
-   (github-models-host "models.github.ai")
-   (github-models-endpoint "/inference/chat/completions")
-   (github-models-model "gpt-4o-mini")
-
-   ;; Ollama configuration.
-   (ollama-model "llama3.2:3b")
-   (ollama-host (or (getenv "MACHER_TEST_OLLAMA_HOST") "localhost:11434"))
-   ;; Seed for consistent responses. You might need to adjust this when changing the model.
-   (ollama-seed 5678)
+   ;; Test endpoint configuration, read from environment variables.
+   ;; MACHER_TEST_OPENAI_BASE_URL is the base URL (without /chat/completions).
+   ;; MACHER_TEST_OPENAI_KEY is the API key (optional for local servers).
+   ;; MACHER_TEST_OPENAI_MODEL is the model name.
+   (test-base-url (getenv "MACHER_TEST_OPENAI_BASE_URL"))
+   (test-api-key (getenv "MACHER_TEST_OPENAI_KEY"))
+   (test-model (getenv "MACHER_TEST_OPENAI_MODEL"))
 
    ;; Timeout in seconds for macher functional tests. Needs to be permissive as tests run in a
    ;; fairly constrained environment on GitHub Actions.
@@ -242,44 +236,53 @@ CALLBACK-TEST is a function that verifies the result."
             (kill-buffer patch-buffer)))))))
 
   (before-all
+    ;; Skip all functional tests if no test endpoint is configured. This
+    ;; registers the specs but marks them as pending so they show up in
+    ;; the test output without running.
+    (assume test-base-url
+            "MACHER_TEST_OPENAI_BASE_URL not set; skipping functional tests")
+
     ;; Allow project.el to detect projects with .project marker file in the root.
     (setq project-vc-extra-root-markers '(".project"))
 
     ;; gptel uses `with-demoted-errors' to swallow errors at some points during the request
     ;; lifecycle. Set 'debug-on-error' globally to cause swallowed errors to actually trigger
     ;; the debugger, which will be interpreted as a proper test error.
-    (setq debug-on-error t))
+    (setq debug-on-error t)
+
+    ;; Configure gptel to use an OpenAI-compatible test endpoint. The base URL is
+    ;; everything up to (but not including) /chat/completions; we append that suffix
+    ;; and parse the result into protocol, host, and endpoint for `gptel-make-openai'.
+    (let* ((full-url (concat (string-trim-right test-base-url "/")
+                             "/chat/completions"))
+           (parsed (url-generic-parse-url full-url))
+           (protocol (url-type parsed))
+           (host (url-host parsed))
+           (port (url-port parsed))
+           (default-port (if (string= protocol "https") 443 80))
+           (host-str (if (and port (/= port default-port))
+                         (format "%s:%d" host port)
+                       host))
+           (endpoint (url-filename parsed))
+           (model (or test-model "gpt-4o-mini"))
+           (api-key (or test-api-key "dummy")))
+      (setq gptel-model model)
+      (setq gptel-directives `(default . ,system-message))
+      (setq gptel-backend
+            (gptel-make-openai
+             "Test endpoint"
+             :host host-str
+             :protocol protocol
+             :endpoint endpoint
+             :key api-key
+             :stream t
+             :models (list model)
+             :request-params '(:temperature 0)))))
 
   (before-each
     ;; Sanity check that trackers are cleaned up between tests.
     (expect temp-files-created :to-be nil)
-    (expect temp-dirs-created :to-be nil)
-
-    ;; Set up gptel configuration for tests.
-    (setq gptel-directives `(default . ,system-message))
-    (if use-github-models
-        ;; CI: Use GitHub Models API (faster, requires internet and token).
-        (progn
-          (setq gptel-model github-models-model)
-          (setq gptel-backend
-                (gptel-make-openai
-                 "GitHub Models"
-                 :host github-models-host
-                 :endpoint github-models-endpoint
-                 :key (getenv "GITHUB_TOKEN")
-                 :stream t
-                 :models `(,gptel-model)
-                 :request-params '(:temperature 0))))
-      ;; Local: Use Ollama (works offline).
-      (setq gptel-model ollama-model)
-      (setq gptel-backend
-            (gptel-make-ollama
-             "Test ollama"
-             :host ollama-host
-             :models `(,gptel-model)
-             ;; Use temperature 0 and a fixed seed for consistent responses.
-             ;; See https://github.com/ollama/ollama/issues/1749.
-             :request-params `(:options (:temperature 0 :seed ,ollama-seed))))))
+    (expect temp-dirs-created :to-be nil))
 
   (after-each
     ;; Verify that all gptel requests have been aborted or terminated.
@@ -297,11 +300,6 @@ CALLBACK-TEST is a function that verifies the result."
     (setq temp-files-created nil)
     (setq temp-dirs-created nil)
 
-    ;; Restore original gptel settings
-    (setq gptel-model original-gptel-model)
-    (setq gptel-directives original-gptel-directives)
-    (setq gptel-backend original-gptel-backend)
-
     ;; If debugging output was enabled (otherwise the buffer won't exist), print it.
     (when (get-buffer "*gptel-log*")
       (with-current-buffer "*gptel-log*"
@@ -310,7 +308,10 @@ CALLBACK-TEST is a function that verifies the result."
   (after-all
     ;; Restore original global settings.
     (setq project-vc-extra-root-markers original-project-vc-extra-root-markers)
-    (setq debug-on-error original-debug-on-error))
+    (setq debug-on-error original-debug-on-error)
+    (setq gptel-model original-gptel-model)
+    (setq gptel-directives original-gptel-directives)
+    (setq gptel-backend original-gptel-backend))
 
   (describe "replace-file operation"
     :var*


### PR DESCRIPTION
Updates CI dependencies and adds retry logic to functional tests that sometimes get rate-limited. 

Also removes the hardcoded backend setup logic (which only supported a specific ollama setup or github models) in functional tests, and allows using more generic OpenAI-compatible endpoints by setting environment variables. If you're working with the repo locally, you can create a `Makefile.local`, which will be included (if it exists) when running `make` commands. See `Makefile.local.example` for the environment variables that you may want to set.

This contains no changes to macher itself, only to dev/CI tooling.