### PR TITLE
fix: include only the most recent user message in patch buffer metadata

### DIFF
--- a/macher.el
+++ b/macher.el
@@ -1264,9 +1264,10 @@ or is aborted.")
 
 - WORKSPACE is the workspace information (same format as `macher--workspace').
 
-- PROMPT is the raw prompt text sent to the LLM (not including any
-  conversation history/prior messages that might also have been
-  included).
+- PROMPT is the most recent user message at the time the request was
+  sent, i.e. the text that actually initiated the request (not
+  including any conversation history/prior messages that might also
+  have been included).
 
   Note the prompt is captured via a prompt transform that gets appended
   to 'gptel-prompt-transform-functions' when applying macher presets.  If
@@ -4059,6 +4060,28 @@ they're accessible on the FSM."
     ;; Update the tools list that the FSM will actually use for tool calls.
     (setf (gptel-fsm-info fsm) (plist-put info :tools processed-tools))))
 
+(defun macher--last-user-prompt ()
+  "Extract the most recent user message from the current buffer.
+
+This is meant to be called from within a gptel prompt transform, where
+the current buffer is a temporary buffer containing the full request
+text.  Text from prior LLM responses and tool calls carries a non-nil
+`gptel' text property, while user-entered text does not.  Returns the
+text after the final response/tool region, with prompt/response
+prefixes stripped, or nil if there's no trailing user text.
+
+As with gptel's own request parsing, if neither `gptel-mode' nor
+`gptel-track-response' is enabled, the entire buffer is treated as user
+input."
+  (let ((start
+         (if (or gptel-mode gptel-track-response)
+             (if (and (> (point-max) (point-min)) (get-text-property (1- (point-max)) 'gptel))
+                 ;; The buffer ends with response/tool text, so there's no trailing user message.
+                 (point-max)
+               (or (previous-single-property-change (point-max) 'gptel) (point-min)))
+           (point-min))))
+    (gptel--trim-prefixes (buffer-substring-no-properties start (point-max)))))
+
 (defun macher--transform-setup-tools (callback fsm)
   "A gptel prompt transform to set up macher tools and behavior.
 
@@ -4080,7 +4103,8 @@ CALLBACK and FSM are as described in the
 `gptel-prompt-transform-functions' documentation."
   (let* (
          ;; Capture information that needs to be included in the macher context if it gets created.
-         (prompt (buffer-string))
+         ;; Note we only capture the most recent user message, not the full conversation text.
+         (prompt (macher--last-user-prompt))
          (process-request-function macher-process-request-function)
          ;; Shared context object for this request, with a lazy initializer.  The context will only
          ;; be initialized if macher tools are invoked during the request.  We use t as a flag that

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -4243,6 +4243,73 @@ Sets `test-patch-content' to the generated patch content for additional assertio
                   ;; Should NOT include header text (has gptel 'ignore property).
                   (expect all-user-content :not :to-match ":discuss:"))))))))
 
+    (it "captures only the latest request in patch metadata for successive actions"
+      ;; Set up backend with responses for two implement actions, each making a tool call.
+      (funcall setup-backend
+               '((:tool-calls
+                  [(:function
+                    (:name
+                     "write_file_in_workspace"
+                     :arguments (:path "first.txt" :content "first content")))])
+                 "First action response"
+                 (:tool-calls
+                  [(:function
+                    (:name
+                     "write_file_in_workspace"
+                     :arguments (:path "second.txt" :content "second content")))])
+                 "Second action response"))
+
+      (let ((macher-action-buffer-ui 'org))
+        (with-current-buffer project-file-buffer
+          ;; Run the FIRST action.
+          (macher-implement "First action instructions" callback)
+
+          ;; Wait for the first action to complete.
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+          (expect callback-called :to-be-truthy)
+          (expect exit-code :to-be nil)
+
+          ;; Reset callback state for the second action.
+          (setq callback-called nil)
+          (setq exit-code nil)
+          (setq callback
+                (macher-test--make-once-only-callback
+                 (lambda (cb-exit-code _cb-execution cb-fsm)
+                   (setq callback-called t)
+                   (setq exit-code cb-exit-code)
+                   (setq fsm cb-fsm))))
+
+          ;; Run the SECOND action, which appends to the same action buffer.
+          (macher-implement "Second action instructions" callback)
+
+          ;; Wait for the second action to complete.
+          (let ((timeout 0))
+            (while (and (not callback-called) (< timeout 100))
+              (sleep-for 0.1)
+              (setq timeout (1+ timeout))))
+          (expect callback-called :to-be-truthy)
+          (expect exit-code :to-be nil)
+
+          ;; Sanity check: the action buffer contains both actions' text.
+          (with-current-buffer (macher-action-buffer)
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (expect content :to-match "First action instructions")
+              (expect content :to-match "First action response")
+              (expect content :to-match "Second action instructions")))
+
+          ;; The patch metadata should contain only the second action's request.
+          (with-current-buffer (macher-patch-buffer)
+            (let ((patch-content (buffer-substring-no-properties (point-min) (point-max))))
+              (expect patch-content :to-match "# PROMPT for patch ID")
+              (expect patch-content :to-match "Second action instructions")
+              (expect patch-content :not :to-match "First action instructions")
+              (expect patch-content :not :to-match "First action response")
+              ;; The org topic headers carry the 'ignore property and are excluded too.
+              (expect patch-content :not :to-match ":implement:"))))))
+
     (it "re-sends aborted action with preset applied via gptel-send"
       ;; Set up backend with responses for: prior action, aborted request (never received),
       ;; re-sent request.

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -4540,6 +4540,112 @@
           (expect (funcall (gptel-tool-function processed-tool) ".") :to-throw)
           (expect warn-called :to-be-truthy)))))
 
+  (describe "macher--last-user-prompt"
+    (it "returns the whole buffer text when there is no conversation history"
+      (with-temp-buffer
+        (insert "implement the thing")
+        (expect (macher--last-user-prompt) :to-equal "implement the thing")))
+
+    (it "returns only the trailing user message in a multi-turn buffer"
+      (with-temp-buffer
+        (insert "first message\n\n")
+        (insert (propertize "first response" 'gptel 'response))
+        (insert "\n\nsecond message")
+        (expect (macher--last-user-prompt) :to-equal "second message")))
+
+    (it "returns nil when the buffer ends with response text"
+      (with-temp-buffer
+        (insert "message\n\n")
+        (insert (propertize "response" 'gptel 'response))
+        (expect (macher--last-user-prompt) :to-be nil)))
+
+    (it "returns nil for an empty buffer"
+      (with-temp-buffer
+        (expect (macher--last-user-prompt) :to-be nil)))
+
+    (it "treats text after tool-call regions as the user message"
+      (with-temp-buffer
+        (insert "message\n\n")
+        (insert (propertize "tool output" 'gptel '(tool . "id")))
+        (insert "\n\nfollowup")
+        (expect (macher--last-user-prompt) :to-equal "followup")))
+
+    (it "treats the whole buffer as user input when response tracking is disabled"
+      (with-temp-buffer
+        (setq-local gptel-track-response nil)
+        (insert "message\n\n")
+        (insert (propertize "response" 'gptel 'response))
+        (insert "\n\nfollowup")
+        (expect (macher--last-user-prompt) :to-equal "message\n\nresponse\n\nfollowup")))
+
+    (it "strips prompt prefixes from the captured message"
+      (with-temp-buffer
+        (let ((gptel-prompt-prefix-alist '((fundamental-mode . "### "))))
+          (insert "first message\n\n")
+          (insert (propertize "first response" 'gptel 'response))
+          (insert "\n\n### second message")
+          (expect (macher--last-user-prompt) :to-equal "second message")))))
+
+  (describe "macher--transform-setup-tools"
+    :var (original-tools request-buffer)
+
+    (before-each
+      (funcall setup-project)
+      (setq original-tools gptel--known-tools)
+      (setq gptel--known-tools nil)
+      (macher--install-tools)
+      (setq request-buffer (find-file-noselect project-file)))
+
+    (after-each
+      (kill-buffer request-buffer)
+      (setq gptel--known-tools original-tools))
+
+    ;; Helper logic shared by the capture tests: run the transform against the current buffer's
+    ;; content, simulate the first state transition (which wraps tools with the context injector),
+    ;; and invoke a wrapped tool to force lazy context creation.  Returns the created context.
+    (cl-flet ((capture-context
+               (fsm)
+               (dolist (handler (cdr (assq 'WAIT (gptel-fsm-handlers fsm))))
+                 (funcall handler fsm))
+               (let ((processed-tool (car (plist-get (gptel-fsm-info fsm) :tools))))
+                 (ignore-errors
+                   (funcall (gptel-tool-function processed-tool) "file1.txt")))
+               (macher--context-for-fsm fsm)))
+
+      (it "captures only the most recent user message as the context prompt"
+        (let* ((read-tool (gptel-get-tool (list macher-tool-category "read_file_in_workspace")))
+               ;; No handlers: we only want the transition handlers that the transform itself
+               ;; installs, not gptel's own request-sending handlers.
+               (fsm (gptel-make-fsm :table gptel-request--transitions :handlers nil))
+               (callback-called nil))
+          (setf (gptel-fsm-info fsm)
+                (plist-put
+                 (plist-put (gptel-fsm-info fsm) :buffer request-buffer)
+                 :tools (list read-tool)))
+          (with-temp-buffer
+            (insert "first message\n\n")
+            (insert (propertize "first response" 'gptel 'response))
+            (insert "\n\nsecond message")
+            (macher--transform-setup-tools (lambda () (setq callback-called t)) fsm))
+          (expect callback-called :to-be-truthy)
+          (let ((context (capture-context fsm)))
+            (expect context :to-be-truthy)
+            (expect (macher-context-prompt context) :to-equal "second message"))))
+
+      (it "captures the whole buffer text when there is no conversation history"
+        (let* ((read-tool (gptel-get-tool (list macher-tool-category "read_file_in_workspace")))
+               (fsm (gptel-make-fsm :table gptel-request--transitions :handlers nil)))
+          (setf (gptel-fsm-info fsm)
+                (plist-put
+                 (plist-put (gptel-fsm-info fsm) :buffer request-buffer)
+                 :tools (list read-tool)))
+          (with-temp-buffer
+            (insert "implement the thing")
+            (macher--transform-setup-tools #'ignore fsm))
+          (let ((context (capture-context fsm)))
+            (expect context :to-be-truthy)
+            (expect (macher-context-prompt context) :to-equal "implement the thing"))))))
+
   (describe "macher--context-for-fsm"
     (before-each
       (funcall setup-project))


### PR DESCRIPTION
Previously the prompt captured for the patch buffer's PROMPT metadata block was the entire request buffer text, i.e. the full gptel conversation history. This was a relic from before macher worked well in generalized gptel conversations, and made the diff buffer fairly unwieldy.

Capture only the trailing user message instead: the text after the final response/tool region (per gptel's 'gptel text property), with prompt/response prefixes stripped, mirroring gptel's own request parsing. In buffers with no conversation history, behavior is unchanged - the whole buffer text is still captured.