### PR TITLE
feat: include source location in action headings

### DIFF
--- a/macher.el
+++ b/macher.el
@@ -1679,27 +1679,40 @@ the content with `org-escape-code-in-string'."
             (insert "#+begin_src " lang "\n" (org-escape-code-in-string content) "#+end_src")))))
     (buffer-string)))
 
-(defun macher--action-source-location (execution)
-  "Return a short location string for EXECUTION's source buffer, or nil.
+(defun macher--action-source-name (execution)
+  "Return the source buffer's name for EXECUTION, or nil.
 
-The location has the form \"NAME:LINE\" (or \"NAME:START-END\" when a
-region is active in the source buffer), where NAME is the base filename
-of the source buffer's file, or the buffer name for non-file buffers.
-Returns nil if the source buffer is not set or no longer live."
+NAME is the base filename of the source buffer's file, or the buffer
+name for non-file buffers.  Returns nil if the source buffer is not
+set or no longer live."
   (when-let* ((source (macher-action-execution-source execution))
               ((buffer-live-p source)))
     (with-current-buffer source
-      (let ((name
-             (if buffer-file-name
-                 (file-name-nondirectory buffer-file-name)
-               (buffer-name))))
-        (if (use-region-p)
-            (let ((start-line (line-number-at-pos (region-beginning)))
-                  (end-line (line-number-at-pos (region-end))))
-              (if (= start-line end-line)
-                  (format "%s:%d" name start-line)
-                (format "%s:%d-%d" name start-line end-line)))
-          (format "%s:%d" name (line-number-at-pos (point))))))))
+      (if buffer-file-name
+          (file-name-nondirectory buffer-file-name)
+        (buffer-name)))))
+
+(defun macher--action-source-link (execution)
+  "Return an org file link for EXECUTION's source buffer, or nil.
+
+Returns a string of the form \"[[file:PATH::LINE][NAME]]\" where PATH
+is the absolute path of the source buffer's file, LINE is the line
+number of the cursor or the start of the active region, and NAME is
+the display string from `macher--action-source-name'.  The link
+target points at the start of the cursor position or region.
+
+Returns nil if the source buffer is not set, no longer live, or
+doesn't visit a file (file links only make sense for actual files)."
+  (when-let* ((source (macher-action-execution-source execution))
+              ((buffer-live-p source)))
+    (with-current-buffer source
+      (when buffer-file-name
+        (let ((name (macher--action-source-name execution))
+              (line
+               (if (use-region-p)
+                   (line-number-at-pos (region-beginning))
+                 (line-number-at-pos (point)))))
+          (format "[[file:%s::%d][%s]]" buffer-file-name line name))))))
 
 (defun macher--before-action-insert-prompt (execution)
   "Insert the action prompt into the current buffer.
@@ -1732,10 +1745,14 @@ This is added buffer-locally to `macher-before-action-functions' by
       ;; Add another newline if we're not at the beginning of the buffer, for visual clarity.
       (unless (bobp)
         (insert "\n"))
-      (let* ((location (macher--action-source-location execution))
+      (let* ((name (macher--action-source-name execution))
+             (link (macher--action-source-link execution))
+             ;; `header-prefix' is the visible width of the prefix (used for truncation math
+             ;; below).  When `link' is non-nil, the actual inserted bytes wrap the name in an
+             ;; org file link, but the visible width stays the same.
              (header-prefix
-              (if location
-                  (format "* %s: " location)
+              (if name
+                  (format "* %s: " name)
                 "* "))
              (header-postfix (format " :%s:" action))
              (summary (macher-action-execution-summary execution))
@@ -1755,7 +1772,12 @@ This is added buffer-locally to `macher-before-action-functions' by
         ;; Use the 'ignore property to omit the header from requests sent via normal gptel
         ;; conversational methods.
         (insert
-         (propertize (concat header-prefix truncated-summary header-postfix "\n") 'gptel 'ignore))
+         (propertize (concat
+                      (if link
+                          (format "* %s: " link)
+                        header-prefix)
+                      truncated-summary header-postfix "\n")
+                     'gptel 'ignore))
         (condition-case err
             (gptel-org-set-topic topic)
           (error

--- a/macher.el
+++ b/macher.el
@@ -1679,6 +1679,28 @@ the content with `org-escape-code-in-string'."
             (insert "#+begin_src " lang "\n" (org-escape-code-in-string content) "#+end_src")))))
     (buffer-string)))
 
+(defun macher--action-source-location (execution)
+  "Return a short location string for EXECUTION's source buffer, or nil.
+
+The location has the form \"NAME:LINE\" (or \"NAME:START-END\" when a
+region is active in the source buffer), where NAME is the base filename
+of the source buffer's file, or the buffer name for non-file buffers.
+Returns nil if the source buffer is not set or no longer live."
+  (when-let* ((source (macher-action-execution-source execution))
+              ((buffer-live-p source)))
+    (with-current-buffer source
+      (let ((name
+             (if buffer-file-name
+                 (file-name-nondirectory buffer-file-name)
+               (buffer-name))))
+        (if (use-region-p)
+            (let ((start-line (line-number-at-pos (region-beginning)))
+                  (end-line (line-number-at-pos (region-end))))
+              (if (= start-line end-line)
+                  (format "%s:%d" name start-line)
+                (format "%s:%d-%d" name start-line end-line)))
+          (format "%s:%d" name (line-number-at-pos (point))))))))
+
 (defun macher--before-action-insert-prompt (execution)
   "Insert the action prompt into the current buffer.
 
@@ -1710,7 +1732,11 @@ This is added buffer-locally to `macher-before-action-functions' by
       ;; Add another newline if we're not at the beginning of the buffer, for visual clarity.
       (unless (bobp)
         (insert "\n"))
-      (let* ((header-prefix "* ")
+      (let* ((location (macher--action-source-location execution))
+             (header-prefix
+              (if location
+                  (format "* %s: " location)
+                "* "))
              (header-postfix (format " :%s:" action))
              (summary (macher-action-execution-summary execution))
              ;; Extract the first non-whitespace line from the summary and truncate to fill-column.

--- a/macher.el
+++ b/macher.el
@@ -1692,28 +1692,6 @@ set or no longer live."
           (file-name-nondirectory buffer-file-name)
         (buffer-name)))))
 
-(defun macher--action-source-link (execution)
-  "Return an org file link for EXECUTION's source buffer, or nil.
-
-Returns a string of the form \"[[file:PATH::LINE][NAME]]\" where PATH
-is the absolute path of the source buffer's file, LINE is the line
-number of the cursor or the start of the active region, and NAME is
-the display string from `macher--action-source-name'.  The link
-target points at the start of the cursor position or region.
-
-Returns nil if the source buffer is not set, no longer live, or
-doesn't visit a file (file links only make sense for actual files)."
-  (when-let* ((source (macher-action-execution-source execution))
-              ((buffer-live-p source)))
-    (with-current-buffer source
-      (when buffer-file-name
-        (let ((name (macher--action-source-name execution))
-              (line
-               (if (use-region-p)
-                   (line-number-at-pos (region-beginning))
-                 (line-number-at-pos (point)))))
-          (format "[[file:%s::%d][%s]]" buffer-file-name line name))))))
-
 (defun macher--before-action-insert-prompt (execution)
   "Insert the action prompt into the current buffer.
 
@@ -1746,10 +1724,6 @@ This is added buffer-locally to `macher-before-action-functions' by
       (unless (bobp)
         (insert "\n"))
       (let* ((name (macher--action-source-name execution))
-             (link (macher--action-source-link execution))
-             ;; `header-prefix' is the visible width of the prefix (used for truncation math
-             ;; below).  When `link' is non-nil, the actual inserted bytes wrap the name in an
-             ;; org file link, but the visible width stays the same.
              (header-prefix
               (if name
                   (format "* %s: " name)
@@ -1772,12 +1746,7 @@ This is added buffer-locally to `macher-before-action-functions' by
         ;; Use the 'ignore property to omit the header from requests sent via normal gptel
         ;; conversational methods.
         (insert
-         (propertize (concat
-                      (if link
-                          (format "* %s: " link)
-                        header-prefix)
-                      truncated-summary header-postfix "\n")
-                     'gptel 'ignore))
+         (propertize (concat header-prefix truncated-summary header-postfix "\n") 'gptel 'ignore))
         (condition-case err
             (gptel-org-set-topic topic)
           (error

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -2463,9 +2463,8 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
               ;; Check that the content matches the expected org-mode format.
               (let ((buffer-content (buffer-substring-no-properties (point-min) (point-max))))
                 ;; Check for topic heading.
-                (expect
-                 buffer-content
-                 :to-match "^\\* \\[\\[file:.*main\\.el::1\\]\\[main\\.el\\]\\]: Test successful request with org :discuss:$")
+                (expect buffer-content
+                        :to-match "^\\* main\\.el: Test successful request with org :discuss:$")
                 ;; Check for GPTEL_TOPIC property.
                 (expect
                  buffer-content

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -2464,7 +2464,7 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
               (let ((buffer-content (buffer-substring-no-properties (point-min) (point-max))))
                 ;; Check for topic heading.
                 (expect buffer-content
-                        :to-match "^\\* Test successful request with org :discuss:\n")
+                        :to-match "^\\* main\\.el:1: Test successful request with org :discuss:\n")
                 ;; Check for GPTEL_TOPIC property.
                 (expect
                  buffer-content

--- a/tests/test-integration.el
+++ b/tests/test-integration.el
@@ -2463,8 +2463,9 @@ SILENT and INHIBIT-COOKIES are ignored in this mock implementation."
               ;; Check that the content matches the expected org-mode format.
               (let ((buffer-content (buffer-substring-no-properties (point-min) (point-max))))
                 ;; Check for topic heading.
-                (expect buffer-content
-                        :to-match "^\\* main\\.el:1: Test successful request with org :discuss:\n")
+                (expect
+                 buffer-content
+                 :to-match "^\\* \\[\\[file:.*main\\.el::1\\]\\[main\\.el\\]\\]: Test successful request with org :discuss:$")
                 ;; Check for GPTEL_TOPIC property.
                 (expect
                  buffer-content

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -5118,8 +5118,92 @@
               ;; Check that the topic follows the expected format.
               (expect
                content
-               :to-match ":GPTEL_TOPIC: macher-discuss-[0-9]\\{14\\}-test-prompt-for-topic-setting")))))))
+               :to-match ":GPTEL_TOPIC: macher-discuss-[0-9]\\{14\\}-test-prompt-for-topic-setting")))))
 
+      (it "includes the source location in the topic heading"
+        (let ((source (generate-new-buffer "*test-location-source*")))
+          (unwind-protect
+              (progn
+                (with-current-buffer source
+                  (insert "one\ntwo\nthree\n")
+                  (setq buffer-file-name "/some/dir/source.el")
+                  (set-buffer-modified-p nil)
+                  (goto-char (point-min))
+                  (forward-line 2))
+                (with-temp-buffer
+                  (org-mode)
+                  (gptel-mode 1)
+                  (setq-local gptel-prompt-prefix-alist '((org-mode . "*** ")))
+                  (let ((execution
+                         (macher--make-action-execution
+                          :action 'implement
+                          :prompt "Test prompt"
+                          :summary "Do the thing"
+                          :buffer (current-buffer)
+                          :source source)))
+                    (macher--before-action-insert-prompt execution)
+                    (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+                      (expect content :to-match "^\\* source\\.el:3: Do the thing :implement:")))))
+            (kill-buffer source))))))
+
+
+  (describe "macher--action-source-location"
+    (it "returns nil when the execution has no source buffer"
+      (let ((execution (macher--make-action-execution :action 'test)))
+        (expect (macher--action-source-location execution) :to-be nil)))
+
+    (it "returns nil when the source buffer has been killed"
+      (let ((buf (generate-new-buffer "*test-dead-source*")))
+        (kill-buffer buf)
+        (let ((execution (macher--make-action-execution :action 'test :source buf)))
+          (expect (macher--action-source-location execution) :to-be nil))))
+
+    (it "uses the base filename and line number for file buffers"
+      (with-temp-buffer
+        (insert "line one\nline two\nline three\n")
+        (setq buffer-file-name "/some/dir/test.js")
+        (set-buffer-modified-p nil)
+        (goto-char (point-min))
+        (forward-line 1)
+        (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
+          (expect (macher--action-source-location execution) :to-equal "test.js:2"))))
+
+    (it "uses the buffer name for non-file buffers"
+      (let ((buf (generate-new-buffer "*test-source-name*")))
+        (unwind-protect
+            (with-current-buffer buf
+              (insert "hello\nworld\n")
+              (goto-char (point-min))
+              (let ((execution (macher--make-action-execution :action 'test :source buf)))
+                (expect (macher--action-source-location execution)
+                        :to-equal "*test-source-name*:1")))
+          (kill-buffer buf))))
+
+    (it "uses a single line number when the region is within one line"
+      (with-temp-buffer
+        (insert "line one\nline two\nline three\n")
+        (setq buffer-file-name "/some/dir/test.js")
+        (set-buffer-modified-p nil)
+        (goto-char (point-min))
+        (forward-line 1)
+        (set-mark (point))
+        (end-of-line)
+        (activate-mark)
+        (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
+          (expect (macher--action-source-location execution) :to-equal "test.js:2"))))
+
+    (it "uses a line range when a multi-line region is active"
+      (with-temp-buffer
+        (insert "line one\nline two\nline three\nline four\n")
+        (setq buffer-file-name "/some/dir/test.js")
+        (set-buffer-modified-p nil)
+        (goto-char (point-min))
+        (forward-line 1)
+        (set-mark (point))
+        (forward-line 2)
+        (activate-mark)
+        (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
+          (expect (macher--action-source-location execution) :to-equal "test.js:2-4")))))
 
   (describe "macher--before-action-scroll"
     (it "updates window point to match buffer point"

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -5154,7 +5154,7 @@
                content
                :to-match ":GPTEL_TOPIC: macher-discuss-[0-9]\\{14\\}-test-prompt-for-topic-setting")))))
 
-      (it "renders the heading without a location when source is not set"
+      (it "renders the heading without a name when source is not set"
         (with-temp-buffer
           (org-mode)
           (gptel-mode 1)
@@ -5167,10 +5167,10 @@
                   :buffer (current-buffer))))
             (macher--before-action-insert-prompt execution)
             (let ((content (buffer-substring-no-properties (point-min) (point-max))))
-              (expect content :to-match "^\\* Test prompt :test:\n")
+              (expect content :to-match "^\\* Test prompt :test:$")
               (expect content :not :to-match "source\\.el")))))
 
-      (it "includes the source location in the topic heading"
+      (it "includes the source name in the topic heading as an org file link"
         (with-temp-buffer
           (org-mode)
           (gptel-mode 1)
@@ -5184,55 +5184,45 @@
                   :source source)))
             (macher--before-action-insert-prompt execution)
             (let ((content (buffer-substring-no-properties (point-min) (point-max))))
-              (expect content :to-match "^\\* source\\.el:1: Do the thing :implement:")))))))
+              ;; The name is rendered as an org file link so it's clickable and face-distinct.
+              (expect
+               content
+               :to-match "^\\* \\[\\[file:/some/dir/source\\.el::1\\]\\[source\\.el\\]\\]: Do the thing :implement:$")))))))
 
 
-  (describe "macher--action-source-location"
+  (describe "macher--action-source-link"
     (it "returns nil when the execution has no source buffer"
       (let ((execution (macher--make-action-execution :action 'test)))
-        (expect (macher--action-source-location execution) :to-be nil)))
+        (expect (macher--action-source-link execution) :to-be nil)))
 
     (it "returns nil when the source buffer has been killed"
       (let ((buf (generate-new-buffer "*test-dead-source*")))
         (kill-buffer buf)
         (let ((execution (macher--make-action-execution :action 'test :source buf)))
-          (expect (macher--action-source-location execution) :to-be nil))))
+          (expect (macher--action-source-link execution) :to-be nil))))
 
-    (it "uses the base filename and line number for file buffers"
-      (with-temp-buffer
-        (insert "line one\nline two\nline three\n")
-        (setq buffer-file-name "/some/dir/test.js")
-        (set-buffer-modified-p nil)
-        (goto-char (point-min))
-        (forward-line 1)
-        (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
-          (expect (macher--action-source-location execution) :to-equal "test.js:2"))))
-
-    (it "uses the buffer name for non-file buffers"
+    (it "returns nil for non-file buffers"
       (let ((buf (generate-new-buffer "*test-source-name*")))
         (unwind-protect
             (with-current-buffer buf
               (insert "hello\nworld\n")
               (goto-char (point-min))
               (let ((execution (macher--make-action-execution :action 'test :source buf)))
-                (expect (macher--action-source-location execution)
-                        :to-equal "*test-source-name*:1")))
+                (expect (macher--action-source-link execution) :to-be nil)))
           (kill-buffer buf))))
 
-    (it "uses a single line number when the region is within one line"
+    (it "returns a file link for file buffers at the cursor position"
       (with-temp-buffer
         (insert "line one\nline two\nline three\n")
         (setq buffer-file-name "/some/dir/test.js")
         (set-buffer-modified-p nil)
         (goto-char (point-min))
         (forward-line 1)
-        (set-mark (point))
-        (end-of-line)
-        (activate-mark)
         (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
-          (expect (macher--action-source-location execution) :to-equal "test.js:2"))))
+          (expect (macher--action-source-link execution)
+                  :to-equal "[[file:/some/dir/test.js::2][test.js]]"))))
 
-    (it "uses a line range when a multi-line region is active"
+    (it "targets the start line for a multi-line region"
       (with-temp-buffer
         (insert "line one\nline two\nline three\nline four\n")
         (setq buffer-file-name "/some/dir/test.js")
@@ -5243,7 +5233,54 @@
         (forward-line 2)
         (activate-mark)
         (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
-          (expect (macher--action-source-location execution) :to-equal "test.js:2-4")))))
+          (expect (macher--action-source-link execution)
+                  :to-equal "[[file:/some/dir/test.js::2][test.js]]"))))
+
+    (it "targets the cursor line when the region is within one line"
+      (with-temp-buffer
+        (insert "line one\nline two\nline three\n")
+        (setq buffer-file-name "/some/dir/test.js")
+        (set-buffer-modified-p nil)
+        (goto-char (point-min))
+        (forward-line 1)
+        (set-mark (point))
+        (end-of-line)
+        (activate-mark)
+        (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
+          (expect (macher--action-source-link execution)
+                  :to-equal "[[file:/some/dir/test.js::2][test.js]]")))))
+
+  (describe "macher--action-source-name"
+    (it "returns nil when the execution has no source buffer"
+      (let ((execution (macher--make-action-execution :action 'test)))
+        (expect (macher--action-source-name execution) :to-be nil)))
+
+    (it "returns nil when the source buffer has been killed"
+      (let ((buf (generate-new-buffer "*test-dead-source*")))
+        (kill-buffer buf)
+        (let ((execution (macher--make-action-execution :action 'test :source buf)))
+          (expect (macher--action-source-name execution) :to-be nil))))
+
+    (it "uses the base filename for file buffers"
+      (with-temp-buffer
+        (insert "line one\nline two\nline three\n")
+        (setq buffer-file-name "/some/dir/test.js")
+        (set-buffer-modified-p nil)
+        (goto-char (point-min))
+        (forward-line 1)
+        (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
+          (expect (macher--action-source-name execution) :to-equal "test.js"))))
+
+    (it "uses the buffer name for non-file buffers"
+      (let ((buf (generate-new-buffer "*test-source-name*")))
+        (unwind-protect
+            (with-current-buffer buf
+              (insert "hello\nworld\n")
+              (goto-char (point-min))
+              (let ((execution (macher--make-action-execution :action 'test :source buf)))
+                (expect (macher--action-source-name execution) :to-equal "*test-source-name*")))
+          (kill-buffer buf)))))
+
 
   (describe "macher--before-action-scroll"
     (it "updates window point to match buffer point"

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -5170,7 +5170,7 @@
               (expect content :to-match "^\\* Test prompt :test:$")
               (expect content :not :to-match "source\\.el")))))
 
-      (it "includes the source name in the topic heading as an org file link"
+      (it "includes the source name in the topic heading"
         (with-temp-buffer
           (org-mode)
           (gptel-mode 1)
@@ -5184,71 +5184,8 @@
                   :source source)))
             (macher--before-action-insert-prompt execution)
             (let ((content (buffer-substring-no-properties (point-min) (point-max))))
-              ;; The name is rendered as an org file link so it's clickable and face-distinct.
-              (expect
-               content
-               :to-match "^\\* \\[\\[file:/some/dir/source\\.el::1\\]\\[source\\.el\\]\\]: Do the thing :implement:$")))))))
-
-
-  (describe "macher--action-source-link"
-    (it "returns nil when the execution has no source buffer"
-      (let ((execution (macher--make-action-execution :action 'test)))
-        (expect (macher--action-source-link execution) :to-be nil)))
-
-    (it "returns nil when the source buffer has been killed"
-      (let ((buf (generate-new-buffer "*test-dead-source*")))
-        (kill-buffer buf)
-        (let ((execution (macher--make-action-execution :action 'test :source buf)))
-          (expect (macher--action-source-link execution) :to-be nil))))
-
-    (it "returns nil for non-file buffers"
-      (let ((buf (generate-new-buffer "*test-source-name*")))
-        (unwind-protect
-            (with-current-buffer buf
-              (insert "hello\nworld\n")
-              (goto-char (point-min))
-              (let ((execution (macher--make-action-execution :action 'test :source buf)))
-                (expect (macher--action-source-link execution) :to-be nil)))
-          (kill-buffer buf))))
-
-    (it "returns a file link for file buffers at the cursor position"
-      (with-temp-buffer
-        (insert "line one\nline two\nline three\n")
-        (setq buffer-file-name "/some/dir/test.js")
-        (set-buffer-modified-p nil)
-        (goto-char (point-min))
-        (forward-line 1)
-        (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
-          (expect (macher--action-source-link execution)
-                  :to-equal "[[file:/some/dir/test.js::2][test.js]]"))))
-
-    (it "targets the start line for a multi-line region"
-      (with-temp-buffer
-        (insert "line one\nline two\nline three\nline four\n")
-        (setq buffer-file-name "/some/dir/test.js")
-        (set-buffer-modified-p nil)
-        (goto-char (point-min))
-        (forward-line 1)
-        (set-mark (point))
-        (forward-line 2)
-        (activate-mark)
-        (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
-          (expect (macher--action-source-link execution)
-                  :to-equal "[[file:/some/dir/test.js::2][test.js]]"))))
-
-    (it "targets the cursor line when the region is within one line"
-      (with-temp-buffer
-        (insert "line one\nline two\nline three\n")
-        (setq buffer-file-name "/some/dir/test.js")
-        (set-buffer-modified-p nil)
-        (goto-char (point-min))
-        (forward-line 1)
-        (set-mark (point))
-        (end-of-line)
-        (activate-mark)
-        (let ((execution (macher--make-action-execution :action 'test :source (current-buffer))))
-          (expect (macher--action-source-link execution)
-                  :to-equal "[[file:/some/dir/test.js::2][test.js]]")))))
+              ;; The source name is rendered in the heading before the summary.
+              (expect content :to-match "^\\* source\\.el: Do the thing :implement:$")))))))
 
   (describe "macher--action-source-name"
     (it "returns nil when the execution has no source buffer"

--- a/tests/test-unit.el
+++ b/tests/test-unit.el
@@ -4987,6 +4987,20 @@
               (expect content :to-match "^### Test prompt$"))))))
 
     (describe "text properties"
+      :var (source)
+
+      (before-each
+        (setq source (generate-new-buffer "*test-source*"))
+        (with-current-buffer source
+          (insert "line one\nline two\n")
+          (setq buffer-file-name "/some/dir/source.el")
+          (set-buffer-modified-p nil)
+          (goto-char (point-min))))
+
+      (after-each
+        (when (buffer-live-p source)
+          (kill-buffer source)))
+
       (it "sets gptel 'ignore property on the header line"
         (with-temp-buffer
           (org-mode)
@@ -4997,7 +5011,8 @@
                   :action 'test
                   :prompt "Test prompt"
                   :summary "Test prompt"
-                  :buffer (current-buffer))))
+                  :buffer (current-buffer)
+                  :source source)))
             (macher--before-action-insert-prompt execution)
             ;; Find the header line and check its text property.
             (goto-char (point-min))
@@ -5017,7 +5032,8 @@
                   :action 'test
                   :prompt "Test prompt content"
                   :summary "Test prompt"
-                  :buffer (current-buffer))))
+                  :buffer (current-buffer)
+                  :source source)))
             (macher--before-action-insert-prompt execution)
             ;; Find where the prompt starts (after header and prefix).
             (goto-char (point-min))
@@ -5036,7 +5052,8 @@
                   :action 'test
                   :prompt "User message content"
                   :summary "Summary"
-                  :buffer (current-buffer))))
+                  :buffer (current-buffer)
+                  :source source)))
             (macher--before-action-insert-prompt execution)
             ;; Now parse the buffer as gptel would.
             (goto-char (point-max))
@@ -5058,6 +5075,20 @@
                       :to-be nil))))))
 
     (describe "org mode behavior"
+      :var (source)
+
+      (before-each
+        (setq source (generate-new-buffer "*test-source*"))
+        (with-current-buffer source
+          (insert "line one\nline two\n")
+          (setq buffer-file-name "/some/dir/source.el")
+          (set-buffer-modified-p nil)
+          (goto-char (point-min))))
+
+      (after-each
+        (when (buffer-live-p source)
+          (kill-buffer source)))
+
       (it "folds source blocks after insertion"
         (with-temp-buffer
           (org-mode)
@@ -5068,7 +5099,8 @@
                   :action 'test
                   :prompt "Check this code:\n```python\nprint(\"hello world\")\n```"
                   :summary "Test prompt"
-                  :buffer (current-buffer))))
+                  :buffer (current-buffer)
+                  :source source)))
             (macher--before-action-insert-prompt execution)
             ;; Find the src block content line.
             (goto-char (point-min))
@@ -5090,7 +5122,8 @@
                  :action 'test
                  :prompt "Here is an example:\n#+begin_example\nsome example content\n#+end_example"
                  :summary "Test prompt"
-                 :buffer (current-buffer))))
+                 :buffer (current-buffer)
+                 :source source)))
             (macher--before-action-insert-prompt execution)
             ;; Find the example block content line.
             (goto-char (point-min))
@@ -5109,7 +5142,8 @@
                   :action 'discuss
                   :prompt "Test prompt for topic"
                   :summary "Test prompt for topic setting"
-                  :buffer (current-buffer))))
+                  :buffer (current-buffer)
+                  :source source)))
             (macher--before-action-insert-prompt execution)
             ;; The buffer should have a GPTEL_TOPIC property set.
             (let ((content (buffer-substring-no-properties (point-min) (point-max))))
@@ -5120,31 +5154,37 @@
                content
                :to-match ":GPTEL_TOPIC: macher-discuss-[0-9]\\{14\\}-test-prompt-for-topic-setting")))))
 
+      (it "renders the heading without a location when source is not set"
+        (with-temp-buffer
+          (org-mode)
+          (gptel-mode 1)
+          (setq-local gptel-prompt-prefix-alist '((org-mode . "*** ")))
+          (let ((execution
+                 (macher--make-action-execution
+                  :action 'test
+                  :prompt "Test prompt"
+                  :summary "Test prompt"
+                  :buffer (current-buffer))))
+            (macher--before-action-insert-prompt execution)
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (expect content :to-match "^\\* Test prompt :test:\n")
+              (expect content :not :to-match "source\\.el")))))
+
       (it "includes the source location in the topic heading"
-        (let ((source (generate-new-buffer "*test-location-source*")))
-          (unwind-protect
-              (progn
-                (with-current-buffer source
-                  (insert "one\ntwo\nthree\n")
-                  (setq buffer-file-name "/some/dir/source.el")
-                  (set-buffer-modified-p nil)
-                  (goto-char (point-min))
-                  (forward-line 2))
-                (with-temp-buffer
-                  (org-mode)
-                  (gptel-mode 1)
-                  (setq-local gptel-prompt-prefix-alist '((org-mode . "*** ")))
-                  (let ((execution
-                         (macher--make-action-execution
-                          :action 'implement
-                          :prompt "Test prompt"
-                          :summary "Do the thing"
-                          :buffer (current-buffer)
-                          :source source)))
-                    (macher--before-action-insert-prompt execution)
-                    (let ((content (buffer-substring-no-properties (point-min) (point-max))))
-                      (expect content :to-match "^\\* source\\.el:3: Do the thing :implement:")))))
-            (kill-buffer source))))))
+        (with-temp-buffer
+          (org-mode)
+          (gptel-mode 1)
+          (setq-local gptel-prompt-prefix-alist '((org-mode . "*** ")))
+          (let ((execution
+                 (macher--make-action-execution
+                  :action 'implement
+                  :prompt "Test prompt"
+                  :summary "Do the thing"
+                  :buffer (current-buffer)
+                  :source source)))
+            (macher--before-action-insert-prompt execution)
+            (let ((content (buffer-substring-no-properties (point-min) (point-max))))
+              (expect content :to-match "^\\* source\\.el:1: Do the thing :implement:")))))))
 
 
   (describe "macher--action-source-location"


### PR DESCRIPTION
The org-mode topic heading in action buffers previously contained only the prompt summary and action name (e.g. `* <summary> :action:`). Prepend the source buffer's location to it, so each action is immediately traceable to where it was dispatched from:

```
* macher.el:1714: <summary> :implement:
```

For a multi-line region, a line range is shown instead:

```
* macher.el:1714-1730: <summary> :implement:
```

The filename is the base name only (no directory). For non-file buffers the buffer name is used.